### PR TITLE
🐛 Fix roulette money tracking bug

### DIFF
--- a/BUG_ANALYSIS.txt
+++ b/BUG_ANALYSIS.txt
@@ -1,0 +1,12 @@
+// Fixed roulette.js money calculation bug
+// 
+// BUG: Money wasn't tallying correctly because:
+// 1. Bets were deducted when placed (line ~105)
+// 2. clearBets() refunded all bets (line ~131)
+// 3. But clearBets() is called AFTER adding winnings (line ~163)
+//    This caused the player to get their bet back even when they lost!
+//
+// SOLUTION: Only refund bets in clearBets() if explicitly cleared by user,
+//           not after every spin.
+
+// The fix is to separate "clear bets for new round" from "refund bets"

--- a/static/js/games/roulette.js
+++ b/static/js/games/roulette.js
@@ -117,13 +117,15 @@ function updateBetDisplay(betType) {
     }
 }
 
-function clearBets() {
+function clearBets(refund = true) {
     if (gameState.isSpinning) return;
     
-    // Refund all bets
-    Object.values(gameState.bets).forEach(amount => {
-        gameState.totalMoney += amount;
-    });
+    // Only refund if explicitly clearing (not after a spin)
+    if (refund) {
+        Object.values(gameState.bets).forEach(amount => {
+            gameState.totalMoney += amount;
+        });
+    }
     
     gameState.bets = {};
     
@@ -138,7 +140,7 @@ function clearBets() {
     spinBtn.classList.remove('btn-spin-ready');
     
     updateDisplay();
-    console.log('🗑️ All bets cleared');
+    console.log(refund ? '🗑️ All bets cleared and refunded' : '🗑️ Bets cleared for new round');
 }
 
 function updateDisplay() {
@@ -321,6 +323,7 @@ function finishSpin(winningNumber) {
         }
     });
     
+    // Add winnings to total money
     gameState.totalMoney += totalWin;
     
     // Show result
@@ -343,8 +346,8 @@ function finishSpin(winningNumber) {
         showMessage(resultMessage, 'info');
     }
     
-    // Reset for next round
-    clearBets();
+    // Reset for next round (don't refund - bets were already deducted!)
+    clearBets(false);
     updateDisplay();
     
     console.log(`🎲 Result: ${winningNumber.num} (${winningNumber.color}) - Net: $${netResult}`);


### PR DESCRIPTION
## Problem
Money wasn't tallying correctly in the roulette game. Players were getting their bets refunded even when losing.

## Root Cause
The `clearBets()` function was refunding all bets after every spin, including losses. The flow was:
1. Player places bet → money deducted
2. Spin completes → winnings added
3. `clearBets()` called → ALL bets refunded 😱
4. Result: Players never actually lost money!

## Solution
Modified `clearBets()` to accept an optional `refund` parameter:
- `clearBets(true)`: User manually clears bets → refund money ✅
- `clearBets(false)`: After spin completes → don't refund (already paid) ✅

## Changes
- `static/js/games/roulette.js`: Updated clearBets() function
- `BUG_ANALYSIS.txt`: Documentation of the bug and fix

## Testing
Money now correctly:
- ✅ Decreases when player loses
- ✅ Increases by (payout - original bet) when player wins  
- ✅ Gets refunded when player manually clears bets

Closes #6