### PR TITLE
🐛 Fix roulette ball position alignment

### DIFF
--- a/static/js/games/roulette.js
+++ b/static/js/games/roulette.js
@@ -243,9 +243,10 @@ function spinWheel() {
     const segmentAngle = (Math.PI * 2) / rouletteNumbers.length;
     const extraSpins = 5; // Number of full rotations before stopping
     
-    // Calculate target: rotate to position winning segment at top (270° or -π/2)
+    // Calculate target: rotate to position winning segment CENTER at top (270° or -π/2)
     // Account for current rotation and add extra spins
-    const targetAngle = (Math.PI * 2 * extraSpins) - (winningIndex * segmentAngle) + (Math.PI / 2);
+    // Subtract half segment angle to align segment CENTER with ball
+    const targetAngle = (Math.PI * 2 * extraSpins) - (winningIndex * segmentAngle) - (segmentAngle / 2) + (Math.PI / 2);
     const startRotation = gameState.wheelRotation % (Math.PI * 2);
     const targetRotation = startRotation + targetAngle;
     


### PR DESCRIPTION
## Problem
Ball stopping position didn't visually align with the actual number rolled. The ball would stop but the number displayed would be slightly off from where the ball appeared to land.

## Root Cause
The target rotation calculation was positioning the winning segment's **edge** at the ball location (top), not the segment's **center**. This caused a noticeable offset.

## Solution
Modified the target angle calculation to subtract half the segment angle:
```javascript
const targetAngle = ... - (winningIndex * segmentAngle) - (segmentAngle / 2) + offset;
```

This aligns the segment CENTER with the ball position at the top.

## Testing
- Ball now accurately stops at the center of the winning number
- Visual alignment matches the displayed result
- Works for all 37 segments (0-36)

Closes #5