### PR TITLE
🔥 HOTFIX: Fix Tambola socket import breaking app

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,6 +92,7 @@ def create_app(config_name='default'):
     from games.digit_guess.socket_events import register_digit_guess_events
     from games.pictionary.socket_events import register_pictionary_events
     from games.mafia.routes import register_mafia_handlers
+    from games.tambola.socket_events import register_tambola_events
 
     # After creating socketio
     register_poker_events(socketio)
@@ -103,6 +104,7 @@ def create_app(config_name='default'):
     register_digit_guess_events(socketio)
     register_pictionary_events(socketio)
     register_mafia_handlers(socketio)
+    register_tambola_events(socketio)
 
 
     # Login required decorator

--- a/games/tambola/socket_events.py
+++ b/games/tambola/socket_events.py
@@ -1,50 +1,49 @@
 """Tambola game Socket.IO events for real-time gameplay."""
 
 from flask_socketio import emit, join_room, leave_room
-from app import socketio
 
 
-@socketio.on('tambola_join')
-def handle_join(data):
-    """Handle player joining a Tambola game room."""
-    game_id = data.get('game_id')
-    player_id = data.get('player_id')
+def register_tambola_events(socketio):
+    """Register all Tambola Socket.IO event handlers."""
     
-    join_room(f'tambola_{game_id}')
-    emit('player_joined', {
-        'player_id': player_id
-    }, room=f'tambola_{game_id}')
+    @socketio.on('tambola_join')
+    def handle_join(data):
+        """Handle player joining a Tambola game room."""
+        game_id = data.get('game_id')
+        player_id = data.get('player_id')
+        
+        join_room(f'tambola_{game_id}')
+        emit('player_joined', {
+            'player_id': player_id
+        }, room=f'tambola_{game_id}')
 
+    @socketio.on('tambola_call_number')
+    def handle_call_number(data):
+        """Handle host calling a number."""
+        game_id = data.get('game_id')
+        # TODO: Implement number calling logic
+        emit('number_called', {
+            'number': 0,  # Placeholder
+            'message': 'Not implemented yet'
+        }, room=f'tambola_{game_id}')
 
-@socketio.on('tambola_call_number')
-def handle_call_number(data):
-    """Handle host calling a number."""
-    game_id = data.get('game_id')
-    # TODO: Implement number calling logic
-    emit('number_called', {
-        'number': 0,  # Placeholder
-        'message': 'Not implemented yet'
-    }, room=f'tambola_{game_id}')
+    @socketio.on('tambola_mark_number')
+    def handle_mark_number(data):
+        """Handle player marking a number on their ticket."""
+        # TODO: Implement number marking
+        pass
 
-
-@socketio.on('tambola_mark_number')
-def handle_mark_number(data):
-    """Handle player marking a number on their ticket."""
-    # TODO: Implement number marking
-    pass
-
-
-@socketio.on('tambola_claim_win')
-def handle_claim_win(data):
-    """Handle player claiming a win."""
-    game_id = data.get('game_id')
-    player_id = data.get('player_id')
-    win_type = data.get('win_type')
-    
-    # TODO: Verify win and broadcast result
-    emit('win_claimed', {
-        'player_id': player_id,
-        'win_type': win_type,
-        'verified': False,
-        'message': 'Not implemented yet'
-    }, room=f'tambola_{game_id}')
+    @socketio.on('tambola_claim_win')
+    def handle_claim_win(data):
+        """Handle player claiming a win."""
+        game_id = data.get('game_id')
+        player_id = data.get('player_id')
+        win_type = data.get('win_type')
+        
+        # TODO: Verify win and broadcast result
+        emit('win_claimed', {
+            'player_id': player_id,
+            'win_type': win_type,
+            'verified': False,
+            'message': 'Not implemented yet'
+        }, room=f'tambola_{game_id}')


### PR DESCRIPTION
## Critical Bug Fix

**Issue:** GameLab2 completely broken with error: `cannot import name socket from app`

**Root Cause:** 
`games/tambola/socket_events.py` was trying to do `from app import socketio` but socketio is created inside `create_app()` function, not at module level.

**Fix:**
- Changed Tambola socket_events to use registration pattern like other games
- Added `register_tambola_events(socketio)` function
- Registered in app.py with other socket event handlers

**Files Changed:**
- `games/tambola/socket_events.py` - Use registration pattern
- `app.py` - Import and register Tambola events

**Testing:**
- App should start without import errors
- Tambola socket events will work when called

**Priority:** CRITICAL - App is broken on main without this fix