### PR TITLE
Add iOS + tvOS app — phone as controller, Apple TV as game board

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -1,0 +1,324 @@
+name: iOS + tvOS → TestFlight
+
+on:
+  push:
+    branches: [main]
+    paths: ["ios/**"]          # only runs when Swift code changes
+  workflow_dispatch:           # manual trigger from GitHub Actions tab
+    inputs:
+      target:
+        description: "Which app to deploy"
+        required: true
+        default: "both"
+        type: choice
+        options: [both, ios, tvos]
+
+concurrency:
+  group: ios-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Build check on every PR (no signing, no upload) ────────────────────────
+  build-check:
+    name: Build check (simulator)
+    runs-on: macos-15
+    if: github.event_name == 'pull_request'
+    defaults:
+      run:
+        working-directory: ios
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Resolve SPM packages
+        run: xcodebuild -resolvePackageDependencies -workspace GameLab.xcworkspace -scheme GameLabController
+
+      - name: Build iOS (simulator, no signing)
+        run: |
+          xcodebuild build \
+            -workspace GameLab.xcworkspace \
+            -scheme GameLabController \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty
+
+      - name: Build tvOS (simulator, no signing)
+        run: |
+          xcodebuild build \
+            -workspace GameLab.xcworkspace \
+            -scheme GameLabTV \
+            -configuration Debug \
+            -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation)" \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty
+
+  # ── Deploy iOS controller app to TestFlight ─────────────────────────────────
+  deploy-ios:
+    name: Deploy iOS → TestFlight
+    runs-on: macos-15
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.target == 'both' || github.event.inputs.target == 'ios'))
+    defaults:
+      run:
+        working-directory: ios
+    environment: testflight       # requires approval in GitHub environments (optional)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Install XcodeGen + xcpretty
+        run: brew install xcodegen && gem install xcpretty
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      # ── Code signing ──────────────────────────────────────────────────────
+      - name: Install Apple Distribution certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          CERT_PATH=$RUNNER_TEMP/dist.p12
+
+          # Create a temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import distribution certificate
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+      - name: Install iOS provisioning profile
+        env:
+          IOS_PROVISION_PROFILE_BASE64: ${{ secrets.IOS_PROVISION_PROFILE_BASE64 }}
+        run: |
+          PP_PATH=$RUNNER_TEMP/ios.mobileprovision
+          echo -n "$IOS_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+          # Extract UUID for later reference
+          PROFILE_UUID=$(security cms -D -i "$PP_PATH" | \
+            plutil -extract UUID raw -)
+          echo "IOS_PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_ENV
+
+      # ── Build & Archive ───────────────────────────────────────────────────
+      - name: Set build number
+        run: |
+          agvtool new-version -all ${{ github.run_number }}
+
+      - name: Archive iOS app
+        env:
+          IOS_PROVISION_PROFILE_NAME: ${{ secrets.IOS_PROVISION_PROFILE_NAME }}
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+        run: |
+          xcodebuild archive \
+            -workspace GameLab.xcworkspace \
+            -scheme GameLabController \
+            -configuration Release \
+            -destination generic/platform=iOS \
+            -archivePath $RUNNER_TEMP/GameLabController.xcarchive \
+            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="$IOS_PROVISION_PROFILE_NAME" \
+            | xcpretty
+
+      - name: Export IPA
+        env:
+          IOS_PROVISION_PROFILE_NAME: ${{ secrets.IOS_PROVISION_PROFILE_NAME }}
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+        run: |
+          cat > $RUNNER_TEMP/ios-export.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>app-store</string>
+            <key>teamID</key><string>${{ secrets.DEVELOPMENT_TEAM }}</string>
+            <key>provisioningProfiles</key><dict>
+              <key>com.gamelab.controller</key>
+              <string>${{ secrets.IOS_PROVISION_PROFILE_NAME }}</string>
+            </dict>
+          </dict></plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/GameLabController.xcarchive \
+            -exportPath $RUNNER_TEMP/ios-export \
+            -exportOptionsPlist $RUNNER_TEMP/ios-export.plist
+
+      # ── Upload to TestFlight ──────────────────────────────────────────────
+      - name: Upload iOS to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: |
+          # Write the API key to a temp file
+          KEY_PATH=$RUNNER_TEMP/asc_key.p8
+          echo -n "$ASC_PRIVATE_KEY" > "$KEY_PATH"
+
+          xcrun altool --upload-app \
+            --type ios \
+            --file $RUNNER_TEMP/ios-export/GameLabController.ipa \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID" \
+            --private-key "$KEY_PATH" \
+            --show-progress
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/signing.keychain-db 2>/dev/null || true
+
+  # ── Deploy tvOS board app to TestFlight ────────────────────────────────────
+  deploy-tvos:
+    name: Deploy tvOS → TestFlight
+    runs-on: macos-15
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.target == 'both' || github.event.inputs.target == 'tvos'))
+    defaults:
+      run:
+        working-directory: ios
+    environment: testflight
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Install XcodeGen + xcpretty
+        run: brew install xcodegen && gem install xcpretty
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Install Apple Distribution certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          CERT_PATH=$RUNNER_TEMP/dist.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+      - name: Install tvOS provisioning profile
+        env:
+          TVOS_PROVISION_PROFILE_BASE64: ${{ secrets.TVOS_PROVISION_PROFILE_BASE64 }}
+        run: |
+          PP_PATH=$RUNNER_TEMP/tvos.mobileprovision
+          echo -n "$TVOS_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+      - name: Set build number
+        run: agvtool new-version -all ${{ github.run_number }}
+
+      - name: Archive tvOS app
+        env:
+          TVOS_PROVISION_PROFILE_NAME: ${{ secrets.TVOS_PROVISION_PROFILE_NAME }}
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+        run: |
+          xcodebuild archive \
+            -workspace GameLab.xcworkspace \
+            -scheme GameLabTV \
+            -configuration Release \
+            -destination generic/platform=tvOS \
+            -archivePath $RUNNER_TEMP/GameLabTV.xcarchive \
+            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="$TVOS_PROVISION_PROFILE_NAME" \
+            | xcpretty
+
+      - name: Export IPA
+        env:
+          TVOS_PROVISION_PROFILE_NAME: ${{ secrets.TVOS_PROVISION_PROFILE_NAME }}
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+        run: |
+          cat > $RUNNER_TEMP/tvos-export.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>app-store</string>
+            <key>teamID</key><string>${{ secrets.DEVELOPMENT_TEAM }}</string>
+            <key>provisioningProfiles</key><dict>
+              <key>com.gamelab.tv</key>
+              <string>${{ secrets.TVOS_PROVISION_PROFILE_NAME }}</string>
+            </dict>
+          </dict></plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/GameLabTV.xcarchive \
+            -exportPath $RUNNER_TEMP/tvos-export \
+            -exportOptionsPlist $RUNNER_TEMP/tvos-export.plist
+
+      - name: Upload tvOS to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: |
+          KEY_PATH=$RUNNER_TEMP/asc_key.p8
+          echo -n "$ASC_PRIVATE_KEY" > "$KEY_PATH"
+          xcrun altool --upload-app \
+            --type appletvos \
+            --file $RUNNER_TEMP/tvos-export/GameLabTV.ipa \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID" \
+            --private-key "$KEY_PATH" \
+            --show-progress
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/signing.keychain-db 2>/dev/null || true

--- a/ios/GameLabController/App/GameLabControllerApp.swift
+++ b/ios/GameLabController/App/GameLabControllerApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct GameLabControllerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootControllerView()
+                .onAppear {
+                    GameSocketManager.shared.connect(to: AppConstants.serverURL)
+                }
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/ios/GameLabController/App/RootControllerView.swift
+++ b/ios/GameLabController/App/RootControllerView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct RootControllerView: View {
+    @StateObject private var vm = ControllerRootViewModel()
+
+    var body: some View {
+        ZStack {
+            Color(hex: "0a0a14").ignoresSafeArea()
+
+            switch vm.screen {
+            case .join:
+                JoinRoomView(onJoin: vm.joinRoom)
+
+            case .waiting(let room):
+                WaitingView(room: room, onReady: vm.markReady)
+
+            case .playing(let room, let privateData):
+                ControllerGameView(
+                    room: room,
+                    privateData: privateData,
+                    onAction: vm.sendAction
+                )
+
+            case .results(let room):
+                ResultsControllerView(room: room, onLeave: vm.leaveRoom)
+            }
+        }
+        .environmentObject(vm)
+        .animation(.easeInOut(duration: 0.3), value: vm.screen.id)
+    }
+}
+
+// MARK: - Screen enum
+
+enum ControllerScreen: Equatable {
+    case join
+    case waiting(Room)
+    case playing(Room, [String: Any])
+    case results(Room)
+
+    static func == (lhs: ControllerScreen, rhs: ControllerScreen) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    var id: String {
+        switch self {
+        case .join:            return "join"
+        case .waiting(let r): return "waiting-\(r.code)"
+        case .playing(let r, _): return "playing-\(r.code)"
+        case .results(let r): return "results-\(r.code)"
+        }
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+final class ControllerRootViewModel: ObservableObject {
+    @Published var screen: ControllerScreen = .join
+
+    private let socket = GameSocketManager.shared
+    private var playerID = AppConstants.deviceID
+
+    init() {
+        socket.on(.roomUpdated) { [weak self] (room: Room) in
+            guard let self else { return }
+            switch room.state {
+            case .lobby:   self.screen = .waiting(room)
+            case .results: self.screen = .results(room)
+            case .playing: break  // wait for privateState before switching
+            }
+        }
+
+        socket.on(.privateState) { [weak self] (r: PrivateStateResponse) in
+            guard let self, r.playerID == self.playerID else { return }
+            if case .waiting(let room) = self.screen {
+                self.screen = .playing(room, r.privateData.mapValues(\.value))
+            } else if case .playing(let room, _) = self.screen {
+                self.screen = .playing(room, r.privateData.mapValues(\.value))
+            }
+        }
+    }
+
+    func joinRoom(code: String, name: String) {
+        let payload = JoinRoomPayload(
+            roomCode: code.uppercased(),
+            playerName: name,
+            playerID: playerID,
+            isTV: false
+        )
+        socket.emit(.joinRoom, payload: payload)
+    }
+
+    func markReady() {
+        guard case .waiting(let room) = screen else { return }
+        socket.emit(.playerReady, payload: ["roomCode": room.code, "playerID": playerID])
+    }
+
+    func sendAction(action: String, data: [String: Any]) {
+        guard case .playing(let room, _) = screen else { return }
+        let payload = GameActionPayload(
+            roomCode: room.code,
+            playerID: playerID,
+            action: action,
+            data: data.mapValues { AnyCodable($0) }
+        )
+        socket.emit(.gameAction, payload: payload)
+    }
+
+    func leaveRoom() {
+        screen = .join
+    }
+}

--- a/ios/GameLabController/App/RootControllerView.swift
+++ b/ios/GameLabController/App/RootControllerView.swift
@@ -11,6 +11,12 @@ struct RootControllerView: View {
             case .join:
                 JoinRoomView(onJoin: vm.joinRoom)
 
+            case .loading:
+                LoadingJoinView()
+
+            case .error(let message):
+                ErrorJoinView(message: message, onRetry: vm.returnToJoin)
+
             case .waiting(let room):
                 WaitingView(room: room, onReady: vm.markReady)
 
@@ -34,6 +40,8 @@ struct RootControllerView: View {
 
 enum ControllerScreen: Equatable {
     case join
+    case loading
+    case error(String)
     case waiting(Room)
     case playing(Room, [String: Any])
     case results(Room)
@@ -44,10 +52,55 @@ enum ControllerScreen: Equatable {
 
     var id: String {
         switch self {
-        case .join:            return "join"
-        case .waiting(let r): return "waiting-\(r.code)"
+        case .join:              return "join"
+        case .loading:           return "loading"
+        case .error(let msg):    return "error-\(msg)"
+        case .waiting(let r):    return "waiting-\(r.code)"
         case .playing(let r, _): return "playing-\(r.code)"
-        case .results(let r): return "results-\(r.code)"
+        case .results(let r):    return "results-\(r.code)"
+        }
+    }
+}
+
+// MARK: - Loading & Error views
+
+struct LoadingJoinView: View {
+    @State private var dotCount = 0
+    private let timer = Timer.publish(every: 0.45, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            ProgressView().scaleEffect(2.2).tint(.cyan)
+            Text("Joining room" + String(repeating: ".", count: dotCount))
+                .font(.title3).foregroundColor(.white.opacity(0.7))
+                .onReceive(timer) { _ in dotCount = (dotCount + 1) % 4 }
+            Spacer()
+        }
+    }
+}
+
+struct ErrorJoinView: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 60)).foregroundColor(.red)
+            Text(message)
+                .font(.title3.bold()).foregroundColor(.white)
+                .multilineTextAlignment(.center).padding(.horizontal, 40)
+            Button(action: onRetry) {
+                Label("Try Again", systemImage: "arrow.counterclockwise")
+                    .font(.headline).frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.cyan))
+                    .foregroundColor(.black)
+            }
+            .buttonStyle(.plain).padding(.horizontal, 40)
+            Spacer()
         }
     }
 }
@@ -59,36 +112,57 @@ final class ControllerRootViewModel: ObservableObject {
     @Published var screen: ControllerScreen = .join
 
     private let socket = GameSocketManager.shared
-    private var playerID = AppConstants.deviceID
+    private let playerID = AppConstants.deviceID
 
     init() {
+        // Server confirms the join — transition to lobby
+        socket.on(.roomJoined) { [weak self] (response: RoomJoinedResponse) in
+            guard let self else { return }
+            self.screen = .waiting(response.room)
+        }
+
+        // Room state changes (more players join, game ends, etc.)
         socket.on(.roomUpdated) { [weak self] (room: Room) in
             guard let self else { return }
             switch room.state {
-            case .lobby:   self.screen = .waiting(room)
-            case .results: self.screen = .results(room)
-            case .playing: break  // wait for privateState before switching
+            case .lobby:
+                if case .waiting = self.screen { self.screen = .waiting(room) }
+            case .results:
+                self.screen = .results(room)
+            case .playing:
+                break  // privateState event drives the playing transition
             }
         }
 
+        // Private screen update — also drives transition from waiting → playing
         socket.on(.privateState) { [weak self] (r: PrivateStateResponse) in
             guard let self, r.playerID == self.playerID else { return }
-            if case .waiting(let room) = self.screen {
+            switch self.screen {
+            case .waiting(let room), .playing(let room, _):
                 self.screen = .playing(room, r.privateData.mapValues(\.value))
-            } else if case .playing(let room, _) = self.screen {
-                self.screen = .playing(room, r.privateData.mapValues(\.value))
+            default:
+                break
+            }
+        }
+
+        // Server-side errors (room not found, room full, invalid action, etc.)
+        socket.on(.error) { [weak self] (r: ErrorResponse) in
+            guard let self else { return }
+            // Only show error overlay from loading state; in-game errors stay silent
+            if case .loading = self.screen {
+                self.screen = .error(r.message)
             }
         }
     }
 
     func joinRoom(code: String, name: String) {
-        let payload = JoinRoomPayload(
+        screen = .loading
+        socket.emit(.joinRoom, payload: JoinRoomPayload(
             roomCode: code.uppercased(),
             playerName: name,
             playerID: playerID,
             isTV: false
-        )
-        socket.emit(.joinRoom, payload: payload)
+        ))
     }
 
     func markReady() {
@@ -98,16 +172,25 @@ final class ControllerRootViewModel: ObservableObject {
 
     func sendAction(action: String, data: [String: Any]) {
         guard case .playing(let room, _) = screen else { return }
-        let payload = GameActionPayload(
+        socket.emit(.gameAction, payload: GameActionPayload(
             roomCode: room.code,
             playerID: playerID,
             action: action,
             data: data.mapValues { AnyCodable($0) }
-        )
-        socket.emit(.gameAction, payload: payload)
+        ))
     }
 
     func leaveRoom() {
+        switch screen {
+        case .playing(let room, _), .waiting(let room):
+            socket.emit(.leaveRoom, payload: ["roomCode": room.code, "playerID": playerID])
+        default:
+            break
+        }
+        screen = .join
+    }
+
+    func returnToJoin() {
         screen = .join
     }
 }

--- a/ios/GameLabController/Info.plist
+++ b/ios/GameLabController/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMotionUsageDescription</key>
+	<string>GameLab uses motion to let you tilt and shake your phone as a game controller.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>GameLab connects to the game server on your local network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_gamelab._tcp</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/GameLabController/Views/Controllers/ClassicGameControllers.swift
+++ b/ios/GameLabController/Views/Controllers/ClassicGameControllers.swift
@@ -1,0 +1,759 @@
+import SwiftUI
+
+// MARK: - Connect 4 Controller
+
+struct Connect4ControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var isMyTurn: Bool { privateData["isMyTurn"] as? Bool ?? false }
+    private var myColor: String { privateData["color"] as? String ?? "red" }
+    private var columnsFull: Set<Int> {
+        Set((privateData["fullColumns"] as? [Int]) ?? [])
+    }
+
+    @State private var hoveredCol: Int? = nil
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("🟡 Connect 4").font(.headline).foregroundColor(.white)
+                Spacer()
+                Circle()
+                    .fill(myColor == "red" ? Color.red : Color.yellow)
+                    .frame(width: 24, height: 24)
+                Text("You").font(.subheadline).foregroundColor(.white.opacity(0.6))
+            }
+            .padding(20).background(Color.white.opacity(0.04))
+
+            Spacer()
+
+            if isMyTurn {
+                VStack(spacing: 20) {
+                    Text("Drop your disc!").font(.title3.bold()).foregroundColor(.yellow)
+
+                    // 7-column tap strip
+                    HStack(spacing: 8) {
+                        ForEach(0..<7, id: \.self) { col in
+                            let full = columnsFull.contains(col)
+                            Button(action: { if !full { drop(col) } }) {
+                                VStack(spacing: 6) {
+                                    Image(systemName: "chevron.down")
+                                        .font(.caption.bold())
+                                        .foregroundColor(hoveredCol == col ? .yellow : .white.opacity(0.4))
+
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(full ? Color.white.opacity(0.05) : (hoveredCol == col
+                                            ? (myColor == "red" ? Color.red.opacity(0.6) : Color.yellow.opacity(0.6))
+                                            : Color.white.opacity(0.12)))
+                                        .frame(height: 200)
+                                        .overlay(
+                                            full ? Image(systemName: "xmark").foregroundColor(.white.opacity(0.2)) : nil
+                                        )
+
+                                    Text("\(col + 1)").font(.caption2).foregroundColor(.white.opacity(0.5))
+                                }
+                            }
+                            .buttonStyle(.plain).disabled(full)
+                            .simultaneousGesture(DragGesture(minimumDistance: 0)
+                                .onChanged { _ in hoveredCol = col }
+                                .onEnded { _ in hoveredCol = nil }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            } else {
+                waitingLabel("Opponent's turn…")
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "00040d").ignoresSafeArea())
+    }
+
+    private func drop(_ col: Int) {
+        onAction("drop", ["column": col])
+    }
+}
+
+// MARK: - Chess Controller
+
+struct ChessControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var isMyTurn: Bool { privateData["isMyTurn"] as? Bool ?? false }
+    private var myColor: String { privateData["pieceColor"] as? String ?? "white" }
+    private var board: [[String]] {
+        privateData["board"] as? [[String]] ?? Array(repeating: Array(repeating: "", count: 8), count: 8)
+    }
+    private var validMoves: [[Int]] {
+        privateData["validMoves"] as? [[Int]] ?? []
+    }
+
+    @State private var selectedSquare: [Int]? = nil
+
+    private var validMoveSet: Set<String> {
+        Set(validMoves.map { "\($0[0]),\($0[1])" })
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("♟️ Chess").font(.headline).foregroundColor(.white)
+                Spacer()
+                Text(myColor.capitalized).font(.subheadline)
+                    .foregroundColor(myColor == "white" ? .white : .black.opacity(0.8))
+                    .padding(.horizontal, 10).padding(.vertical, 4)
+                    .background(Capsule().fill(myColor == "white" ? Color.white.opacity(0.2) : Color.black.opacity(0.8)))
+            }
+            .padding(16).background(Color.white.opacity(0.04))
+
+            if isMyTurn {
+                Text(selectedSquare == nil ? "Tap your piece" : "Tap destination")
+                    .font(.subheadline).foregroundColor(.cyan.opacity(0.8))
+                    .padding(.vertical, 8)
+            } else {
+                Text("Opponent thinking…").font(.subheadline).foregroundColor(.white.opacity(0.4)).padding(.vertical, 8)
+            }
+
+            // 8×8 board
+            VStack(spacing: 1) {
+                ForEach(0..<8, id: \.self) { row in
+                    HStack(spacing: 1) {
+                        ForEach(0..<8, id: \.self) { col in
+                            let piece = board[row][col]
+                            let isSelected = selectedSquare == [row, col]
+                            let isValidTarget = validMoveSet.contains("\(row),\(col)")
+                            let isLight = (row + col) % 2 == 0
+
+                            Button(action: { tapSquare(row: row, col: col) }) {
+                                ZStack {
+                                    Rectangle().fill(
+                                        isSelected ? Color.yellow.opacity(0.6) :
+                                        isValidTarget ? Color.green.opacity(0.4) :
+                                        isLight ? Color(hex: "f0d9b5") : Color(hex: "b58863")
+                                    )
+                                    if !piece.isEmpty {
+                                        Text(piece).font(.system(size: 28))
+                                    }
+                                    if isValidTarget && piece.isEmpty {
+                                        Circle().fill(Color.green.opacity(0.5)).frame(width: 14, height: 14)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .aspectRatio(1, contentMode: .fit)
+                            }
+                            .buttonStyle(.plain).disabled(!isMyTurn)
+                        }
+                    }
+                }
+            }
+            .padding(8)
+            .background(Color(hex: "1a1a1a"))
+            .cornerRadius(12)
+            .padding(.horizontal, 12)
+
+            if let sel = selectedSquare {
+                Button(action: { selectedSquare = nil }) {
+                    Label("Deselect (\(chessCellLabel(sel[0], sel[1])))", systemImage: "xmark.circle")
+                        .font(.caption).foregroundColor(.white.opacity(0.5))
+                }
+                .buttonStyle(.plain).padding(.top, 8)
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func tapSquare(row: Int, col: Int) {
+        guard isMyTurn else { return }
+        let piece = board[row][col]
+        if let sel = selectedSquare {
+            if validMoveSet.contains("\(row),\(col)") {
+                onAction("move", ["from": sel, "to": [row, col]])
+                selectedSquare = nil
+            } else if !piece.isEmpty {
+                // Re-select different own piece
+                onAction("select", ["row": row, "col": col])
+                selectedSquare = [row, col]
+            } else {
+                selectedSquare = nil
+            }
+        } else if !piece.isEmpty {
+            onAction("select", ["row": row, "col": col])
+            selectedSquare = [row, col]
+        }
+    }
+
+    private func chessCellLabel(_ row: Int, _ col: Int) -> String {
+        let files = ["a","b","c","d","e","f","g","h"]
+        return "\(files[col])\(8 - row)"
+    }
+}
+
+// MARK: - Memory Controller
+
+struct MemoryControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var isMyTurn: Bool { privateData["isMyTurn"] as? Bool ?? false }
+    private var myScore: Int { privateData["myScore"] as? Int ?? 0 }
+    private var flippedIndices: Set<Int> {
+        Set((privateData["flipped"] as? [Int]) ?? [])
+    }
+    private var matchedIndices: Set<Int> {
+        Set((privateData["matched"] as? [Int]) ?? [])
+    }
+    private var cardCount: Int { privateData["cardCount"] as? Int ?? 16 }
+    private var cardValues: [String] {
+        privateData["cardValues"] as? [String] ?? Array(repeating: "?", count: cardCount)
+    }
+
+    private let cols = 4
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("🧩 Memory").font(.headline).foregroundColor(.white)
+                Spacer()
+                Text("Pairs: \(myScore)").font(.subheadline.bold()).foregroundColor(.cyan)
+            }
+            .padding(16).background(Color.white.opacity(0.04))
+
+            Spacer()
+
+            if isMyTurn {
+                Text("Flip two cards!").font(.subheadline).foregroundColor(.green.opacity(0.8))
+                    .padding(.vertical, 8)
+            } else {
+                waitingLabel("Opponent's turn…")
+                    .padding(.vertical, 8)
+            }
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: cols), spacing: 10) {
+                ForEach(0..<cardCount, id: \.self) { idx in
+                    let revealed = flippedIndices.contains(idx) || matchedIndices.contains(idx)
+                    let matched = matchedIndices.contains(idx)
+
+                    Button(action: { tapCard(idx) }) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(matched ? Color.green.opacity(0.3) :
+                                      revealed ? Color.white.opacity(0.15) :
+                                      Color(hex: "1e1e3a"))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .strokeBorder(matched ? Color.green.opacity(0.6) : Color.white.opacity(0.08),
+                                                      lineWidth: 1.5)
+                                )
+
+                            if revealed {
+                                Text(cardValues[idx]).font(.system(size: 28))
+                            } else {
+                                Image(systemName: "questionmark").font(.title2)
+                                    .foregroundColor(.white.opacity(0.3))
+                            }
+                        }
+                        .frame(height: 70)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!isMyTurn || revealed)
+                }
+            }
+            .padding(.horizontal, 16)
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func tapCard(_ index: Int) {
+        guard isMyTurn, !flippedIndices.contains(index), !matchedIndices.contains(index) else { return }
+        onAction("flip", ["index": index])
+    }
+}
+
+// MARK: - Roulette Controller
+
+struct RouletteControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var chips: Int { privateData["chips"] as? Int ?? 100 }
+    private var currentBets: [String: Int] { privateData["bets"] as? [String: Int] ?? [:] }
+    private var isSpinning: Bool { privateData["isSpinning"] as? Bool ?? false }
+    private var lastResult: Int? { privateData["lastResult"] as? Int }
+
+    @State private var selectedChip = 5
+
+    private let chipValues = [1, 5, 25, 100]
+    private let betTargets: [(String, String)] = [
+        ("red", "🔴 Red"), ("black", "⚫ Black"),
+        ("odd", "Odd"), ("even", "Even"),
+        ("1-12", "1st 12"), ("13-24", "2nd 12"), ("25-36", "3rd 12"),
+        ("low", "1–18"), ("high", "19–36"),
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                HStack {
+                    Text("🎡 Roulette").font(.title2.bold()).foregroundColor(.white)
+                    Spacer()
+                    Text("$\(chips)").font(.headline.bold()).foregroundColor(.green)
+                }
+                .padding(.horizontal, 20).padding(.top, 20)
+
+                if let result = lastResult {
+                    Text("Last spin: \(result)").font(.subheadline)
+                        .foregroundColor(.yellow).padding(.horizontal, 20)
+                }
+
+                // Chip selector
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Chip value").font(.caption.bold()).foregroundColor(.white.opacity(0.4))
+                        .padding(.horizontal, 20)
+                    HStack(spacing: 10) {
+                        ForEach(chipValues, id: \.self) { val in
+                            Button(action: { selectedChip = val }) {
+                                Text("$\(val)").font(.headline)
+                                    .frame(width: 64, height: 44)
+                                    .background(RoundedRectangle(cornerRadius: 10)
+                                        .fill(selectedChip == val ? Color.yellow.opacity(0.8) : Color.white.opacity(0.1)))
+                                    .foregroundColor(selectedChip == val ? .black : .white)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        Spacer()
+                        Button(action: clearBets) {
+                            Label("Clear", systemImage: "trash").font(.caption)
+                                .foregroundColor(.red.opacity(0.7))
+                        }
+                        .buttonStyle(.plain).padding(.trailing, 20)
+                    }
+                    .padding(.horizontal, 20)
+                }
+
+                // Bet targets
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],
+                          spacing: 10) {
+                    ForEach(betTargets, id: \.0) { id, label in
+                        BetTile(
+                            label: label,
+                            betAmount: currentBets[id] ?? 0,
+                            onTap: { placeBet(on: id) }
+                        )
+                    }
+                }
+                .padding(.horizontal, 16)
+
+                // Spin button
+                Button(action: spin) {
+                    Text(isSpinning ? "Spinning…" : "🎰 Spin!")
+                        .font(.headline).frame(maxWidth: .infinity).padding(.vertical, 18)
+                        .background(RoundedRectangle(cornerRadius: 14)
+                            .fill(isSpinning ? Color.white.opacity(0.1) : Color.green.opacity(0.85)))
+                        .foregroundColor(isSpinning ? .white.opacity(0.4) : .black)
+                }
+                .buttonStyle(.plain).disabled(isSpinning || currentBets.isEmpty).padding(.horizontal, 20)
+                .padding(.bottom, 30)
+            }
+        }
+        .background(Color(hex: "060d00").ignoresSafeArea())
+    }
+
+    private func placeBet(on target: String) {
+        guard !isSpinning, selectedChip <= chips else { return }
+        onAction("place_bet", ["target": target, "amount": selectedChip])
+    }
+
+    private func clearBets() {
+        onAction("clear_bets", [:])
+    }
+
+    private func spin() {
+        onAction("spin", [:])
+    }
+}
+
+private struct BetTile: View {
+    let label: String
+    let betAmount: Int
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 4) {
+                Text(label).font(.body).foregroundColor(.white)
+                if betAmount > 0 {
+                    Text("$\(betAmount)").font(.caption.bold()).foregroundColor(.green)
+                }
+            }
+            .frame(maxWidth: .infinity).padding(.vertical, 14)
+            .background(RoundedRectangle(cornerRadius: 12)
+                .fill(betAmount > 0 ? Color.green.opacity(0.2) : Color.white.opacity(0.07))
+                .overlay(RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(betAmount > 0 ? Color.green.opacity(0.5) : Color.white.opacity(0.08),
+                                  lineWidth: 1.5)))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Mafia Controller
+
+struct MafiaControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var role: String { privateData["role"] as? String ?? "town" }
+    private var phase: String { privateData["phase"] as? String ?? "day" }
+    private var isAlive: Bool { privateData["isAlive"] as? Bool ?? true }
+    private var players: [[String: Any]] { privateData["players"] as? [[String: Any]] ?? [] }
+    private var myVote: String? { privateData["myVote"] as? String }
+    private var investigateResult: String? { privateData["investigateResult"] as? String }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Role card
+            roleCard
+
+            Spacer()
+
+            if !isAlive {
+                eliminatedView
+            } else if phase == "day" {
+                dayPhaseView
+            } else {
+                nightPhaseView
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: phase == "day" ? "0a0814" : "000814").ignoresSafeArea())
+    }
+
+    private var roleCard: some View {
+        let (emoji, color, desc): (String, Color, String) = {
+            switch role {
+            case "mafia":   return ("🔪", .red, "Eliminate town at night")
+            case "sheriff": return ("⭐", .yellow, "Investigate one player per night")
+            case "doctor":  return ("💉", .green, "Save one player per night")
+            default:        return ("👤", .white, "Vote out Mafia during the day")
+            }
+        }()
+
+        return HStack(spacing: 12) {
+            Text(emoji).font(.system(size: 36))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(role.capitalized).font(.headline).foregroundColor(color)
+                Text(desc).font(.caption).foregroundColor(.white.opacity(0.5))
+            }
+            Spacer()
+            Text(phase == "day" ? "☀️ Day" : "🌙 Night")
+                .font(.caption.bold())
+                .foregroundColor(phase == "day" ? .yellow : .cyan)
+        }
+        .padding(20)
+        .background(color.opacity(0.1))
+    }
+
+    private var dayPhaseView: some View {
+        VStack(spacing: 16) {
+            Text("Vote to eliminate").font(.headline).foregroundColor(.white.opacity(0.7))
+            ForEach(alivePlayers, id: \.0) { id, name in
+                Button(action: { vote(for: id) }) {
+                    HStack {
+                        Text(name).foregroundColor(.white)
+                        Spacer()
+                        if myVote == id {
+                            Label("Your vote", systemImage: "checkmark").font(.caption).foregroundColor(.red)
+                        }
+                    }
+                    .padding(14)
+                    .background(RoundedRectangle(cornerRadius: 12)
+                        .fill(myVote == id ? Color.red.opacity(0.2) : Color.white.opacity(0.06))
+                        .overlay(RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(myVote == id ? Color.red.opacity(0.5) : .clear, lineWidth: 1.5)))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+
+    private var nightPhaseView: some View {
+        VStack(spacing: 16) {
+            switch role {
+            case "mafia":
+                Text("Choose your target").font(.headline).foregroundColor(.red)
+                ForEach(alivePlayers.filter { $0.0 != (privateData["myID"] as? String ?? "") }, id: \.0) { id, name in
+                    Button(action: { nightAction(action: "eliminate", targetID: id) }) {
+                        Text(name).foregroundColor(.white).frame(maxWidth: .infinity).padding(14)
+                            .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.1)))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 24)
+
+            case "doctor":
+                Text("Save someone tonight").font(.headline).foregroundColor(.green)
+                ForEach(alivePlayers, id: \.0) { id, name in
+                    Button(action: { nightAction(action: "save", targetID: id) }) {
+                        Text(name).foregroundColor(.white).frame(maxWidth: .infinity).padding(14)
+                            .background(RoundedRectangle(cornerRadius: 12).fill(Color.green.opacity(0.1)))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 24)
+
+            case "sheriff":
+                Text("Investigate a player").font(.headline).foregroundColor(.yellow)
+                if let result = investigateResult {
+                    Text("Result: \(result)").font(.body.bold())
+                        .foregroundColor(result.lowercased().contains("mafia") ? .red : .green)
+                        .padding(.horizontal, 24)
+                }
+                ForEach(alivePlayers.filter { $0.0 != (privateData["myID"] as? String ?? "") }, id: \.0) { id, name in
+                    Button(action: { nightAction(action: "investigate", targetID: id) }) {
+                        Text(name).foregroundColor(.white).frame(maxWidth: .infinity).padding(14)
+                            .background(RoundedRectangle(cornerRadius: 12).fill(Color.yellow.opacity(0.08)))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 24)
+
+            default:
+                VStack(spacing: 12) {
+                    Text("🌙").font(.system(size: 56))
+                    Text("Sleep tight…\nMafia is choosing their target.").font(.body)
+                        .foregroundColor(.white.opacity(0.5)).multilineTextAlignment(.center)
+                }
+            }
+        }
+    }
+
+    private var eliminatedView: some View {
+        VStack(spacing: 16) {
+            Text("💀").font(.system(size: 72))
+            Text("You were eliminated").font(.title2.bold()).foregroundColor(.red)
+            Text("Watch the TV to see how the game ends.").font(.subheadline)
+                .foregroundColor(.white.opacity(0.5)).multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 40)
+    }
+
+    private var alivePlayers: [(String, String)] {
+        players.compactMap { d -> (String, String)? in
+            guard let id = d["id"] as? String,
+                  let name = d["name"] as? String,
+                  d["isAlive"] as? Bool ?? true else { return nil }
+            return (id, name)
+        }
+    }
+
+    private func vote(for targetID: String) {
+        onAction("vote", ["targetID": targetID])
+    }
+
+    private func nightAction(action: String, targetID: String) {
+        onAction(action, ["targetID": targetID])
+    }
+}
+
+// MARK: - Digit Guess Controller (Mastermind / Bulls & Cows)
+
+struct DigitGuessControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var isMyTurn: Bool { privateData["isMyTurn"] as? Bool ?? true }
+    private var myGuesses: [[String: Any]] { privateData["myGuesses"] as? [[String: Any]] ?? [] }
+    private var won: Bool { privateData["won"] as? Bool ?? false }
+
+    @State private var digits: [Int] = [0, 0, 0, 0]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("🔢 Digit Guess").font(.headline).foregroundColor(.white)
+                Spacer()
+                Text("Guesses: \(myGuesses.count)").font(.subheadline).foregroundColor(.white.opacity(0.5))
+            }
+            .padding(16).background(Color.white.opacity(0.04))
+
+            Spacer()
+
+            if won {
+                VStack(spacing: 12) {
+                    Text("🎉").font(.system(size: 60))
+                    Text("You cracked it!").font(.title2.bold()).foregroundColor(.green)
+                    Text("in \(myGuesses.count) guesses").foregroundColor(.white.opacity(0.5))
+                }
+            } else {
+                VStack(spacing: 24) {
+                    Text("Guess the 4-digit code").font(.subheadline).foregroundColor(.white.opacity(0.5))
+
+                    // 4-digit selectors
+                    HStack(spacing: 12) {
+                        ForEach(0..<4, id: \.self) { pos in
+                            VStack(spacing: 0) {
+                                Button(action: { digits[pos] = (digits[pos] + 1) % 10 }) {
+                                    Image(systemName: "chevron.up").foregroundColor(.white.opacity(0.5)).frame(height: 32)
+                                }
+                                .buttonStyle(.plain)
+
+                                Text("\(digits[pos])")
+                                    .font(.system(size: 40, weight: .bold, design: .monospaced))
+                                    .foregroundColor(.white)
+                                    .frame(width: 60, height: 60)
+                                    .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.1)))
+
+                                Button(action: { digits[pos] = (digits[pos] + 9) % 10 }) {
+                                    Image(systemName: "chevron.down").foregroundColor(.white.opacity(0.5)).frame(height: 32)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+
+                    Button(action: submitGuess) {
+                        Text("Submit Guess").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
+                            .background(RoundedRectangle(cornerRadius: 14)
+                                .fill(isMyTurn ? Color.purple : Color.white.opacity(0.08)))
+                            .foregroundColor(isMyTurn ? .white : .white.opacity(0.3))
+                    }
+                    .buttonStyle(.plain).disabled(!isMyTurn).padding(.horizontal, 24)
+
+                    // Guess history
+                    if !myGuesses.isEmpty {
+                        VStack(spacing: 6) {
+                            Text("Your guesses").font(.caption.bold()).foregroundColor(.white.opacity(0.4))
+                            ForEach(Array(myGuesses.enumerated()), id: \.offset) { _, g in
+                                HStack {
+                                    Text(g["guess"] as? String ?? "????")
+                                        .font(.system(.body, design: .monospaced).bold()).foregroundColor(.white)
+                                    Spacer()
+                                    Text("🐂\(g["bulls"] as? Int ?? 0)  🐄\(g["cows"] as? Int ?? 0)")
+                                        .font(.caption).foregroundColor(.white.opacity(0.6))
+                                }
+                                .padding(.horizontal, 16).padding(.vertical, 8)
+                                .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.04)))
+                            }
+                        }
+                        .padding(.horizontal, 24)
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func submitGuess() {
+        guard isMyTurn else { return }
+        onAction("guess", ["digits": digits, "code": digits.map(String.init).joined()])
+    }
+}
+
+// MARK: - Raja Mantri Controller
+
+struct RajaMantriControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var role: String { privateData["role"] as? String ?? "" }
+    private var phase: String { privateData["phase"] as? String ?? "deal" }
+    private var players: [(String, String)] {
+        let raw = privateData["players"] as? [[String: Any]] ?? []
+        return raw.compactMap { d -> (String, String)? in
+            guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+            return (id, name)
+        }
+    }
+    private var myScore: Int { privateData["score"] as? Int ?? 0 }
+    private var hasGuessed: Bool { privateData["hasGuessed"] as? Bool ?? false }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("👑 Raja Mantri").font(.headline).foregroundColor(.white)
+                Spacer()
+                Text("Score: \(myScore)").font(.subheadline.bold()).foregroundColor(.cyan)
+            }
+            .padding(16).background(Color.white.opacity(0.04))
+
+            Spacer()
+
+            VStack(spacing: 24) {
+                // Role card
+                if !role.isEmpty {
+                    VStack(spacing: 8) {
+                        Text(roleEmoji(role)).font(.system(size: 72))
+                        Text(role).font(.system(size: 32, weight: .bold)).foregroundColor(roleColor(role))
+                        Text(roleDesc(role)).font(.subheadline).foregroundColor(.white.opacity(0.5))
+                            .multilineTextAlignment(.center).padding(.horizontal, 32)
+                    }
+                    .padding(24)
+                    .background(RoundedRectangle(cornerRadius: 20).fill(roleColor(role).opacity(0.08)))
+                    .padding(.horizontal, 24)
+                }
+
+                // Sipahi guesses who is the Chor
+                if role == "Sipahi" && phase == "guess" && !hasGuessed {
+                    VStack(spacing: 12) {
+                        Text("Catch the Chor!").font(.headline.bold()).foregroundColor(.yellow)
+                        Text("Who is the thief?").font(.subheadline).foregroundColor(.white.opacity(0.5))
+                        ForEach(players, id: \.0) { id, name in
+                            Button(action: { onAction("accuse", ["targetID": id]) }) {
+                                HStack {
+                                    Text(name).foregroundColor(.white)
+                                    Spacer()
+                                    Image(systemName: "hand.point.right.fill").foregroundColor(.yellow)
+                                }
+                                .padding(14)
+                                .background(RoundedRectangle(cornerRadius: 12).fill(Color.yellow.opacity(0.1)))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, 24)
+                } else if phase == "wait" || hasGuessed {
+                    Label("Wait for the round to end", systemImage: "hourglass")
+                        .font(.subheadline).foregroundColor(.white.opacity(0.4))
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func roleEmoji(_ r: String) -> String {
+        switch r { case "Raja": return "👑"; case "Mantri": return "🎩"; case "Chor": return "🦹"; default: return "⚔️" }
+    }
+    private func roleColor(_ r: String) -> Color {
+        switch r { case "Raja": return .yellow; case "Mantri": return .purple; case "Chor": return .red; default: return .cyan }
+    }
+    private func roleDesc(_ r: String) -> String {
+        switch r {
+        case "Raja":   return "You are the King. Stay safe."
+        case "Mantri": return "You are the Minister. Protect the Raja."
+        case "Chor":   return "You are the Thief. Hide your identity!"
+        default:       return "You are the Guard. Find the Chor!"
+        }
+    }
+}
+
+// MARK: - Shared helpers
+
+private func waitingLabel(_ text: String) -> some View {
+    Label(text, systemImage: "hourglass")
+        .font(.subheadline).foregroundColor(.white.opacity(0.4))
+}

--- a/ios/GameLabController/Views/Controllers/ControllerGameView.swift
+++ b/ios/GameLabController/Views/Controllers/ControllerGameView.swift
@@ -8,28 +8,34 @@ struct ControllerGameView: View {
 
     var body: some View {
         switch room.gameID {
-        case .heist:
-            HeistControllerView(privateData: privateData, onAction: onAction)
-        case .trivia:
-            TriviaControllerView(privateData: privateData, onAction: onAction)
-        case .poker:
-            PokerControllerView(privateData: privateData, onAction: onAction)
-        case .tambola:
-            TambolaControllerView(privateData: privateData, onAction: onAction)
-        case .stockPanic:
-            StockPanicControllerView(privateData: privateData, onAction: onAction)
-        case .mindMeld:
-            MindMeldControllerView(privateData: privateData, onAction: onAction)
-        case .hotGrid:
-            HotGridControllerView(privateData: privateData, onAction: onAction)
-        case .speedSculptor:
-            SpeedSculptorControllerView(privateData: privateData, onAction: onAction)
-        case .snakeLadder:
-            ShakeToRollControllerView(privateData: privateData, onAction: onAction)
-        case .pong:
-            PongControllerView(privateData: privateData, onAction: onAction)
-        default:
-            GenericTapControllerView(room: room, privateData: privateData, onAction: onAction)
+        // Invented games
+        case .heist:         HeistControllerView(privateData: privateData, onAction: onAction)
+        case .stockPanic:    StockPanicControllerView(privateData: privateData, onAction: onAction)
+        case .mindMeld:      MindMeldControllerView(privateData: privateData, onAction: onAction)
+        case .hotGrid:       HotGridControllerView(privateData: privateData, onAction: onAction)
+        case .speedSculptor: SpeedSculptorControllerView(privateData: privateData, onAction: onAction)
+
+        // Knowledge
+        case .trivia:        TriviaControllerView(privateData: privateData, onAction: onAction)
+        case .digitGuess:    DigitGuessControllerView(privateData: privateData, onAction: onAction)
+
+        // Casino
+        case .poker:         PokerControllerView(privateData: privateData, onAction: onAction)
+        case .tambola:       TambolaControllerView(privateData: privateData, onAction: onAction)
+        case .roulette:      RouletteControllerView(privateData: privateData, onAction: onAction)
+
+        // Social
+        case .mafia:         MafiaControllerView(privateData: privateData, onAction: onAction)
+        case .rajaMantri:    RajaMantriControllerView(privateData: privateData, onAction: onAction)
+
+        // Strategy / Board
+        case .chess:         ChessControllerView(privateData: privateData, onAction: onAction)
+        case .connectFour:   Connect4ControllerView(privateData: privateData, onAction: onAction)
+        case .memory:        MemoryControllerView(privateData: privateData, onAction: onAction)
+        case .snakeLadder:   ShakeToRollControllerView(privateData: privateData, onAction: onAction)
+
+        // Action
+        case .pong:          PongControllerView(privateData: privateData, onAction: onAction)
         }
     }
 }

--- a/ios/GameLabController/Views/Controllers/ControllerGameView.swift
+++ b/ios/GameLabController/Views/Controllers/ControllerGameView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Routes the phone to the correct controller UI based on the game.
+struct ControllerGameView: View {
+    let room: Room
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    var body: some View {
+        switch room.gameID {
+        case .heist:
+            HeistControllerView(privateData: privateData, onAction: onAction)
+        case .trivia:
+            TriviaControllerView(privateData: privateData, onAction: onAction)
+        case .poker:
+            PokerControllerView(privateData: privateData, onAction: onAction)
+        case .tambola:
+            TambolaControllerView(privateData: privateData, onAction: onAction)
+        case .stockPanic:
+            StockPanicControllerView(privateData: privateData, onAction: onAction)
+        case .mindMeld:
+            MindMeldControllerView(privateData: privateData, onAction: onAction)
+        case .hotGrid:
+            HotGridControllerView(privateData: privateData, onAction: onAction)
+        case .speedSculptor:
+            SpeedSculptorControllerView(privateData: privateData, onAction: onAction)
+        case .snakeLadder:
+            ShakeToRollControllerView(privateData: privateData, onAction: onAction)
+        case .pong:
+            PongControllerView(privateData: privateData, onAction: onAction)
+        default:
+            GenericTapControllerView(room: room, privateData: privateData, onAction: onAction)
+        }
+    }
+}

--- a/ios/GameLabController/Views/Controllers/HeistControllerView.swift
+++ b/ios/GameLabController/Views/Controllers/HeistControllerView.swift
@@ -1,0 +1,358 @@
+import SwiftUI
+
+/// Heist phone controller — completely different UI for Guard vs Thief.
+struct HeistControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var role: HeistRole {
+        (privateData["role"] as? String) == "guard" ? .guard : .thief
+    }
+
+    var body: some View {
+        switch role {
+        case .guard:
+            GuardControllerView(privateData: privateData, onAction: onAction)
+        case .thief:
+            ThiefControllerView(privateData: privateData, onAction: onAction)
+        }
+    }
+}
+
+// MARK: - Guard Controller
+// Guard sees camera positions on their phone and sets which cameras are active.
+// This info is PRIVATE — thieves can't see it on the TV until reveal phase.
+
+private struct GuardControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var activeCameras: Set<String> = []
+    @State private var phase: HeistPhase = .guardSets
+    @State private var hasSubmitted = false
+
+    // Camera slots the guard can activate (positions on the grid)
+    private var cameraSlots: [CameraSlot] {
+        (privateData["cameraSlots"] as? [[String: Any]] ?? defaultCameraSlots)
+            .compactMap { dict -> CameraSlot? in
+                guard let id = dict["id"] as? String,
+                      let label = dict["label"] as? String,
+                      let dir = dict["direction"] as? String
+                else { return nil }
+                return CameraSlot(id: id, label: label, direction: dir)
+            }
+    }
+
+    private var defaultCameraSlots: [[String: Any]] {
+        [
+            ["id": "cam_tl", "label": "Top Left",     "direction": "↘"],
+            ["id": "cam_tr", "label": "Top Right",    "direction": "↙"],
+            ["id": "cam_bl", "label": "Bottom Left",  "direction": "↗"],
+            ["id": "cam_br", "label": "Bottom Right", "direction": "↖"],
+        ]
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Role badge
+            roleBadge
+
+            Spacer()
+
+            if phase == .guardSets {
+                VStack(spacing: 28) {
+                    Text("Choose cameras to activate")
+                        .font(.headline)
+                        .foregroundColor(.white.opacity(0.6))
+
+                    Text("Activate up to 2")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.3))
+
+                    // 2×2 camera grid
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                        ForEach(cameraSlots) { slot in
+                            CameraToggleTile(
+                                slot: slot,
+                                isActive: activeCameras.contains(slot.id),
+                                canActivate: activeCameras.count < 2 || activeCameras.contains(slot.id)
+                            ) {
+                                toggleCamera(slot.id)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 24)
+
+                    // Submit
+                    Button(action: submitCameras) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.shield.fill")
+                            Text(hasSubmitted ? "Cameras Set ✓" : "Lock Cameras")
+                                .font(.headline)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(hasSubmitted ? Color.green.opacity(0.3) : Color.red.opacity(0.8))
+                        )
+                        .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(hasSubmitted)
+                    .padding(.horizontal, 24)
+                }
+            } else {
+                // During thieves move phase, guard waits and sees coverage map
+                VStack(spacing: 16) {
+                    Text("📷 Cameras Active")
+                        .font(.title3.bold())
+                        .foregroundColor(.red)
+
+                    Text("Watching for thieves…")
+                        .foregroundColor(.white.opacity(0.5))
+
+                    ForEach(cameraSlots.filter { activeCameras.contains($0.id) }) { slot in
+                        HStack {
+                            Text(slot.direction).font(.title2)
+                            Text(slot.label)
+                                .foregroundColor(.white)
+                            Spacer()
+                            Text("ACTIVE")
+                                .font(.caption.bold())
+                                .foregroundColor(.red)
+                        }
+                        .padding()
+                        .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.15)))
+                        .padding(.horizontal, 24)
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "140000").ignoresSafeArea())
+        .onAppear {
+            if let p = privateData["phase"] as? String {
+                phase = HeistPhase(rawValue: p) ?? .guardSets
+            }
+        }
+    }
+
+    private var roleBadge: some View {
+        HStack(spacing: 12) {
+            Text("🛡")
+                .font(.system(size: 32))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("You are the Guard")
+                    .font(.headline)
+                    .foregroundColor(.red)
+                Text("Only YOU can see camera positions")
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            Spacer()
+        }
+        .padding(20)
+        .background(Color.red.opacity(0.1))
+    }
+
+    private func toggleCamera(_ id: String) {
+        if activeCameras.contains(id) {
+            activeCameras.remove(id)
+        } else if activeCameras.count < 2 {
+            activeCameras.insert(id)
+        }
+    }
+
+    private func submitCameras() {
+        hasSubmitted = true
+        onAction("set_cameras", ["cameras": Array(activeCameras)])
+    }
+}
+
+// MARK: - Thief Controller
+// Thief sees ONLY their position on a simplified map.
+// They pick a direction to move each round.
+
+private struct ThiefControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var hasMoved = false
+    @State private var myPosition: GridPos = .init(col: 1, row: 1)
+    @State private var thiefColor: Color = .cyan
+
+    private var isMovingPhase: Bool {
+        (privateData["phase"] as? String) == HeistPhase.thievesMove.rawValue
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Role badge
+            roleBadge
+
+            Spacer()
+
+            VStack(spacing: 28) {
+                // Mini position indicator
+                HStack(spacing: 12) {
+                    Text("Your position")
+                        .foregroundColor(.white.opacity(0.5))
+                        .font(.subheadline)
+                    Spacer()
+                    Text("C\(myPosition.col) R\(myPosition.row)")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.cyan)
+                }
+                .padding(.horizontal, 24)
+
+                // Direction pad
+                VStack(spacing: 12) {
+                    DirectionButton(symbol: "arrow.up", label: "Up") {
+                        move(direction: "up")
+                    }
+                    HStack(spacing: 40) {
+                        DirectionButton(symbol: "arrow.left", label: "Left") {
+                            move(direction: "left")
+                        }
+                        DirectionButton(symbol: "arrow.right", label: "Right") {
+                            move(direction: "right")
+                        }
+                    }
+                    DirectionButton(symbol: "arrow.down", label: "Down") {
+                        move(direction: "down")
+                    }
+                }
+                .opacity(isMovingPhase && !hasMoved ? 1 : 0.3)
+
+                if hasMoved {
+                    Label("Move sent — waiting for round to end", systemImage: "hourglass")
+                        .font(.subheadline)
+                        .foregroundColor(.cyan.opacity(0.7))
+                } else if !isMovingPhase {
+                    Label("Wait for the Guard to set cameras…", systemImage: "eye")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+
+            Spacer()
+
+            // Tip: avoid lit tiles
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.yellow)
+                Text("Avoid tiles with camera arcs on the TV!")
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 32)
+        }
+        .background(Color(hex: "000d14").ignoresSafeArea())
+        .onAppear {
+            if let col = privateData["col"] as? Int,
+               let row = privateData["row"] as? Int {
+                myPosition = GridPos(col: col, row: row)
+            }
+        }
+    }
+
+    private var roleBadge: some View {
+        HStack(spacing: 12) {
+            Text("🥷")
+                .font(.system(size: 32))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("You are a Thief")
+                    .font(.headline)
+                    .foregroundColor(.cyan)
+                Text("Reach the vault 💰 then escape 🚪")
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            Spacer()
+        }
+        .padding(20)
+        .background(Color.cyan.opacity(0.08))
+    }
+
+    private func move(direction: String) {
+        guard isMovingPhase, !hasMoved else { return }
+        hasMoved = true
+        onAction("move", ["direction": direction])
+    }
+}
+
+// MARK: - Subviews
+
+private struct CameraToggleTile: View {
+    let slot: CameraSlot
+    let isActive: Bool
+    let canActivate: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            VStack(spacing: 10) {
+                Text(slot.direction)
+                    .font(.system(size: 36))
+                Text(slot.label)
+                    .font(.caption)
+                    .foregroundColor(isActive ? .white : .white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                Text(isActive ? "ACTIVE" : "OFF")
+                    .font(.caption2.bold())
+                    .foregroundColor(isActive ? .red : .white.opacity(0.3))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(isActive ? Color.red.opacity(0.25) : Color.white.opacity(0.06))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(isActive ? Color.red.opacity(0.6) : Color.white.opacity(0.08),
+                                          lineWidth: isActive ? 2 : 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .opacity(canActivate ? 1 : 0.4)
+        .disabled(!canActivate && !isActive)
+        .scaleEffect(isActive ? 1.04 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isActive)
+    }
+}
+
+private struct DirectionButton: View {
+    let symbol: String
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Image(systemName: symbol)
+                    .font(.system(size: 28, weight: .semibold))
+                Text(label)
+                    .font(.caption2)
+            }
+            .foregroundColor(.white)
+            .frame(width: 80, height: 80)
+            .background(
+                Circle().fill(Color.white.opacity(0.1))
+                    .overlay(Circle().strokeBorder(Color.cyan.opacity(0.3), lineWidth: 1))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Supporting types
+
+private struct CameraSlot: Identifiable {
+    let id: String
+    let label: String
+    let direction: String
+}

--- a/ios/GameLabController/Views/Controllers/HeistControllerView.swift
+++ b/ios/GameLabController/Views/Controllers/HeistControllerView.swift
@@ -20,271 +20,277 @@ struct HeistControllerView: View {
 }
 
 // MARK: - Guard Controller
-// Guard sees camera positions on their phone and sets which cameras are active.
-// This info is PRIVATE — thieves can't see it on the TV until reveal phase.
 
 private struct GuardControllerView: View {
     let privateData: [String: Any]
     let onAction: (String, [String: Any]) -> Void
 
+    // User interaction state — must persist across re-renders
     @State private var activeCameras: Set<String> = []
-    @State private var phase: HeistPhase = .guardSets
     @State private var hasSubmitted = false
+    @State private var trackedRound = 0
 
-    // Camera slots the guard can activate (positions on the grid)
+    // Derived from privateData — automatically reflects server updates
+    private var phase: HeistPhase {
+        HeistPhase(rawValue: privateData["phase"] as? String ?? "") ?? .guardSets
+    }
+    private var currentRound: Int { privateData["round"] as? Int ?? 0 }
+
     private var cameraSlots: [CameraSlot] {
-        (privateData["cameraSlots"] as? [[String: Any]] ?? defaultCameraSlots)
-            .compactMap { dict -> CameraSlot? in
-                guard let id = dict["id"] as? String,
-                      let label = dict["label"] as? String,
-                      let dir = dict["direction"] as? String
-                else { return nil }
-                return CameraSlot(id: id, label: label, direction: dir)
-            }
+        let raw = privateData["cameraSlots"] as? [[String: Any]] ?? defaultSlots
+        return raw.compactMap { d -> CameraSlot? in
+            guard let id  = d["id"]  as? String,
+                  let lbl = d["label"] as? String,
+                  let dir = d["direction"] as? String else { return nil }
+            return CameraSlot(id: id, label: lbl, direction: dir)
+        }
     }
 
-    private var defaultCameraSlots: [[String: Any]] {
-        [
-            ["id": "cam_tl", "label": "Top Left",     "direction": "↘"],
-            ["id": "cam_tr", "label": "Top Right",    "direction": "↙"],
-            ["id": "cam_bl", "label": "Bottom Left",  "direction": "↗"],
-            ["id": "cam_br", "label": "Bottom Right", "direction": "↖"],
-        ]
-    }
+    private var defaultSlots: [[String: Any]] {[
+        ["id": "cam_tl", "label": "Top Left",     "direction": "↘"],
+        ["id": "cam_tr", "label": "Top Right",    "direction": "↙"],
+        ["id": "cam_bl", "label": "Bottom Left",  "direction": "↗"],
+        ["id": "cam_br", "label": "Bottom Right", "direction": "↖"],
+    ]}
 
     var body: some View {
         VStack(spacing: 0) {
-            // Role badge
             roleBadge
 
             Spacer()
 
             if phase == .guardSets {
-                VStack(spacing: 28) {
-                    Text("Choose cameras to activate")
-                        .font(.headline)
-                        .foregroundColor(.white.opacity(0.6))
-
-                    Text("Activate up to 2")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.3))
-
-                    // 2×2 camera grid
-                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                        ForEach(cameraSlots) { slot in
-                            CameraToggleTile(
-                                slot: slot,
-                                isActive: activeCameras.contains(slot.id),
-                                canActivate: activeCameras.count < 2 || activeCameras.contains(slot.id)
-                            ) {
-                                toggleCamera(slot.id)
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 24)
-
-                    // Submit
-                    Button(action: submitCameras) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "checkmark.shield.fill")
-                            Text(hasSubmitted ? "Cameras Set ✓" : "Lock Cameras")
-                                .font(.headline)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 18)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16)
-                                .fill(hasSubmitted ? Color.green.opacity(0.3) : Color.red.opacity(0.8))
-                        )
-                        .foregroundColor(.white)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(hasSubmitted)
-                    .padding(.horizontal, 24)
-                }
+                guardSetPhase
             } else {
-                // During thieves move phase, guard waits and sees coverage map
-                VStack(spacing: 16) {
-                    Text("📷 Cameras Active")
-                        .font(.title3.bold())
-                        .foregroundColor(.red)
-
-                    Text("Watching for thieves…")
-                        .foregroundColor(.white.opacity(0.5))
-
-                    ForEach(cameraSlots.filter { activeCameras.contains($0.id) }) { slot in
-                        HStack {
-                            Text(slot.direction).font(.title2)
-                            Text(slot.label)
-                                .foregroundColor(.white)
-                            Spacer()
-                            Text("ACTIVE")
-                                .font(.caption.bold())
-                                .foregroundColor(.red)
-                        }
-                        .padding()
-                        .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.15)))
-                        .padding(.horizontal, 24)
-                    }
-                }
+                watchingPhase
             }
 
             Spacer()
         }
         .background(Color(hex: "140000").ignoresSafeArea())
-        .onAppear {
-            if let p = privateData["phase"] as? String {
-                phase = HeistPhase(rawValue: p) ?? .guardSets
+        // Reset per round so Guard picks cameras fresh each round
+        .onChange(of: currentRound) { newRound in
+            guard newRound != trackedRound else { return }
+            trackedRound = newRound
+            hasSubmitted = false
+            activeCameras = []
+        }
+        .onAppear { trackedRound = currentRound }
+    }
+
+    // MARK: - Phases
+
+    private var guardSetPhase: some View {
+        VStack(spacing: 28) {
+            Text("Choose cameras to activate")
+                .font(.headline).foregroundColor(.white.opacity(0.6))
+            Text("Max 2 cameras per round")
+                .font(.caption).foregroundColor(.white.opacity(0.3))
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                ForEach(cameraSlots) { slot in
+                    CameraToggleTile(
+                        slot: slot,
+                        isActive: activeCameras.contains(slot.id),
+                        canActivate: activeCameras.count < 2 || activeCameras.contains(slot.id)
+                    ) { toggleCamera(slot.id) }
+                }
+            }
+            .padding(.horizontal, 24)
+
+            Button(action: submitCameras) {
+                HStack(spacing: 8) {
+                    Image(systemName: hasSubmitted ? "checkmark.shield.fill" : "shield.fill")
+                    Text(hasSubmitted ? "Cameras Locked ✓" : "Lock Cameras")
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity).padding(.vertical, 18)
+                .background(RoundedRectangle(cornerRadius: 16)
+                    .fill(hasSubmitted ? Color.green.opacity(0.3) : Color.red.opacity(0.8)))
+                .foregroundColor(.white)
+            }
+            .buttonStyle(.plain).disabled(hasSubmitted).padding(.horizontal, 24)
+        }
+    }
+
+    private var watchingPhase: some View {
+        VStack(spacing: 16) {
+            Text("📷 Cameras Active")
+                .font(.title3.bold()).foregroundColor(.red)
+            Text("Watching for thieves…")
+                .foregroundColor(.white.opacity(0.5))
+
+            VStack(spacing: 10) {
+                ForEach(cameraSlots.filter { activeCameras.contains($0.id) }) { slot in
+                    HStack {
+                        Text(slot.direction).font(.title2)
+                        Text(slot.label).foregroundColor(.white)
+                        Spacer()
+                        Text("ACTIVE").font(.caption.bold()).foregroundColor(.red)
+                    }
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.15)))
+                    .padding(.horizontal, 24)
+                }
             }
         }
     }
+
+    // MARK: - Subviews & helpers
 
     private var roleBadge: some View {
         HStack(spacing: 12) {
-            Text("🛡")
-                .font(.system(size: 32))
+            Text("🛡").font(.system(size: 32))
             VStack(alignment: .leading, spacing: 2) {
-                Text("You are the Guard")
-                    .font(.headline)
-                    .foregroundColor(.red)
-                Text("Only YOU can see camera positions")
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.5))
+                Text("You are the Guard").font(.headline).foregroundColor(.red)
+                Text("Only YOU can see camera positions").font(.caption).foregroundColor(.white.opacity(0.5))
             }
             Spacer()
+            Text("Round \(currentRound)").font(.caption.bold()).foregroundColor(.white.opacity(0.4))
         }
-        .padding(20)
-        .background(Color.red.opacity(0.1))
+        .padding(20).background(Color.red.opacity(0.1))
     }
 
     private func toggleCamera(_ id: String) {
-        if activeCameras.contains(id) {
-            activeCameras.remove(id)
-        } else if activeCameras.count < 2 {
-            activeCameras.insert(id)
-        }
+        if activeCameras.contains(id) { activeCameras.remove(id) }
+        else if activeCameras.count < 2 { activeCameras.insert(id) }
     }
 
     private func submitCameras() {
+        guard !hasSubmitted else { return }
         hasSubmitted = true
         onAction("set_cameras", ["cameras": Array(activeCameras)])
     }
 }
 
 // MARK: - Thief Controller
-// Thief sees ONLY their position on a simplified map.
-// They pick a direction to move each round.
 
 private struct ThiefControllerView: View {
     let privateData: [String: Any]
     let onAction: (String, [String: Any]) -> Void
 
     @State private var hasMoved = false
-    @State private var myPosition: GridPos = .init(col: 1, row: 1)
-    @State private var thiefColor: Color = .cyan
+    @State private var trackedRound = 0
 
-    private var isMovingPhase: Bool {
-        (privateData["phase"] as? String) == HeistPhase.thievesMove.rawValue
+    private var phase: HeistPhase {
+        HeistPhase(rawValue: privateData["phase"] as? String ?? "") ?? .guardSets
     }
+    private var myPosition: GridPos {
+        GridPos(
+            col: privateData["col"] as? Int ?? 1,
+            row: privateData["row"] as? Int ?? 1
+        )
+    }
+    private var currentRound: Int { privateData["round"] as? Int ?? 0 }
+    private var isMovingPhase: Bool { phase == .thievesMove }
+    private var hasReachedVault: Bool { privateData["hasReachedVault"] as? Bool ?? false }
+    private var isCaught: Bool { privateData["isCaught"] as? Bool ?? false }
 
     var body: some View {
         VStack(spacing: 0) {
-            // Role badge
             roleBadge
 
             Spacer()
 
-            VStack(spacing: 28) {
-                // Mini position indicator
-                HStack(spacing: 12) {
-                    Text("Your position")
-                        .foregroundColor(.white.opacity(0.5))
-                        .font(.subheadline)
-                    Spacer()
-                    Text("C\(myPosition.col) R\(myPosition.row)")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.cyan)
-                }
-                .padding(.horizontal, 24)
-
-                // Direction pad
-                VStack(spacing: 12) {
-                    DirectionButton(symbol: "arrow.up", label: "Up") {
-                        move(direction: "up")
-                    }
-                    HStack(spacing: 40) {
-                        DirectionButton(symbol: "arrow.left", label: "Left") {
-                            move(direction: "left")
-                        }
-                        DirectionButton(symbol: "arrow.right", label: "Right") {
-                            move(direction: "right")
-                        }
-                    }
-                    DirectionButton(symbol: "arrow.down", label: "Down") {
-                        move(direction: "down")
-                    }
-                }
-                .opacity(isMovingPhase && !hasMoved ? 1 : 0.3)
-
-                if hasMoved {
-                    Label("Move sent — waiting for round to end", systemImage: "hourglass")
-                        .font(.subheadline)
-                        .foregroundColor(.cyan.opacity(0.7))
-                } else if !isMovingPhase {
-                    Label("Wait for the Guard to set cameras…", systemImage: "eye")
-                        .font(.subheadline)
-                        .foregroundColor(.white.opacity(0.4))
+            if isCaught {
+                caughtView
+            } else {
+                VStack(spacing: 28) {
+                    positionIndicator
+                    dpad
+                    statusLabel
                 }
             }
 
             Spacer()
 
-            // Tip: avoid lit tiles
-            HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(.yellow)
-                Text("Avoid tiles with camera arcs on the TV!")
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.5))
-            }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 32)
+            cameraWarning
         }
         .background(Color(hex: "000d14").ignoresSafeArea())
-        .onAppear {
-            if let col = privateData["col"] as? Int,
-               let row = privateData["row"] as? Int {
-                myPosition = GridPos(col: col, row: row)
+        .onChange(of: currentRound) { newRound in
+            guard newRound != trackedRound else { return }
+            trackedRound = newRound
+            hasMoved = false
+        }
+        .onAppear { trackedRound = currentRound }
+    }
+
+    private var positionIndicator: some View {
+        HStack(spacing: 12) {
+            Text("Position").foregroundColor(.white.opacity(0.5)).font(.subheadline)
+            Spacer()
+            Text("Col \(myPosition.col)  Row \(myPosition.row)")
+                .font(.system(.body, design: .monospaced)).foregroundColor(.cyan)
+            if hasReachedVault {
+                Text("💰 GOT IT").font(.caption.bold()).foregroundColor(.yellow)
             }
         }
+        .padding(.horizontal, 24)
+    }
+
+    private var dpad: some View {
+        VStack(spacing: 14) {
+            DirectionButton(symbol: "arrow.up",    label: "Up")    { move("up") }
+            HStack(spacing: 48) {
+                DirectionButton(symbol: "arrow.left",  label: "Left")  { move("left") }
+                DirectionButton(symbol: "arrow.right", label: "Right") { move("right") }
+            }
+            DirectionButton(symbol: "arrow.down",  label: "Down")  { move("down") }
+        }
+        .opacity(isMovingPhase && !hasMoved ? 1 : 0.3)
+        .disabled(!isMovingPhase || hasMoved)
+    }
+
+    private var statusLabel: some View {
+        Group {
+            if hasMoved {
+                Label("Move sent — waiting for round end", systemImage: "hourglass")
+                    .font(.subheadline).foregroundColor(.cyan.opacity(0.7))
+            } else if !isMovingPhase {
+                Label("Guard is setting cameras…", systemImage: "eye")
+                    .font(.subheadline).foregroundColor(.white.opacity(0.4))
+            }
+        }
+    }
+
+    private var caughtView: some View {
+        VStack(spacing: 16) {
+            Text("🚨").font(.system(size: 60))
+            Text("You were caught!").font(.title2.bold()).foregroundColor(.red)
+            Text("Watch the TV to see how it ends.").foregroundColor(.white.opacity(0.5))
+        }
+    }
+
+    private var cameraWarning: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow)
+            Text("Avoid red-lit tiles on the TV!")
+                .font(.caption).foregroundColor(.white.opacity(0.5))
+        }
+        .padding(.horizontal, 24).padding(.bottom, 32)
     }
 
     private var roleBadge: some View {
         HStack(spacing: 12) {
-            Text("🥷")
-                .font(.system(size: 32))
+            Text("🥷").font(.system(size: 32))
             VStack(alignment: .leading, spacing: 2) {
-                Text("You are a Thief")
-                    .font(.headline)
-                    .foregroundColor(.cyan)
-                Text("Reach the vault 💰 then escape 🚪")
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.5))
+                Text("You are a Thief").font(.headline).foregroundColor(.cyan)
+                Text("Reach 💰 then escape 🚪").font(.caption).foregroundColor(.white.opacity(0.5))
             }
             Spacer()
+            Text("Round \(currentRound)").font(.caption.bold()).foregroundColor(.white.opacity(0.4))
         }
-        .padding(20)
-        .background(Color.cyan.opacity(0.08))
+        .padding(20).background(Color.cyan.opacity(0.08))
     }
 
-    private func move(direction: String) {
-        guard isMovingPhase, !hasMoved else { return }
+    private func move(_ direction: String) {
+        guard isMovingPhase, !hasMoved, !isCaught else { return }
         hasMoved = true
         onAction("move", ["direction": direction])
     }
 }
 
-// MARK: - Subviews
+// MARK: - Shared subviews
 
 private struct CameraToggleTile: View {
     let slot: CameraSlot
@@ -295,31 +301,23 @@ private struct CameraToggleTile: View {
     var body: some View {
         Button(action: onToggle) {
             VStack(spacing: 10) {
-                Text(slot.direction)
-                    .font(.system(size: 36))
-                Text(slot.label)
-                    .font(.caption)
-                    .foregroundColor(isActive ? .white : .white.opacity(0.5))
+                Text(slot.direction).font(.system(size: 36))
+                Text(slot.label).font(.caption).foregroundColor(isActive ? .white : .white.opacity(0.5))
                     .multilineTextAlignment(.center)
-                Text(isActive ? "ACTIVE" : "OFF")
-                    .font(.caption2.bold())
+                Text(isActive ? "ACTIVE" : "OFF").font(.caption2.bold())
                     .foregroundColor(isActive ? .red : .white.opacity(0.3))
             }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 20)
+            .frame(maxWidth: .infinity).padding(.vertical, 20)
             .background(
                 RoundedRectangle(cornerRadius: 16)
                     .fill(isActive ? Color.red.opacity(0.25) : Color.white.opacity(0.06))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .strokeBorder(isActive ? Color.red.opacity(0.6) : Color.white.opacity(0.08),
-                                          lineWidth: isActive ? 2 : 1)
-                    )
+                    .overlay(RoundedRectangle(cornerRadius: 16)
+                        .strokeBorder(isActive ? Color.red.opacity(0.6) : Color.white.opacity(0.08),
+                                      lineWidth: isActive ? 2 : 1))
             )
         }
         .buttonStyle(.plain)
-        .opacity(canActivate ? 1 : 0.4)
-        .disabled(!canActivate && !isActive)
+        .opacity(canActivate ? 1 : 0.4).disabled(!canActivate && !isActive)
         .scaleEffect(isActive ? 1.04 : 1.0)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isActive)
     }
@@ -333,23 +331,16 @@ private struct DirectionButton: View {
     var body: some View {
         Button(action: action) {
             VStack(spacing: 4) {
-                Image(systemName: symbol)
-                    .font(.system(size: 28, weight: .semibold))
-                Text(label)
-                    .font(.caption2)
+                Image(systemName: symbol).font(.system(size: 28, weight: .semibold))
+                Text(label).font(.caption2)
             }
-            .foregroundColor(.white)
-            .frame(width: 80, height: 80)
-            .background(
-                Circle().fill(Color.white.opacity(0.1))
-                    .overlay(Circle().strokeBorder(Color.cyan.opacity(0.3), lineWidth: 1))
-            )
+            .foregroundColor(.white).frame(width: 80, height: 80)
+            .background(Circle().fill(Color.white.opacity(0.1))
+                .overlay(Circle().strokeBorder(Color.cyan.opacity(0.3), lineWidth: 1)))
         }
         .buttonStyle(.plain)
     }
 }
-
-// MARK: - Supporting types
 
 private struct CameraSlot: Identifiable {
     let id: String

--- a/ios/GameLabController/Views/Controllers/OtherControllerViews.swift
+++ b/ios/GameLabController/Views/Controllers/OtherControllerViews.swift
@@ -494,49 +494,7 @@ struct GenericTapControllerView: View {
     }
 }
 
-// MARK: - Placeholder board views (TV side, other games)
-
-struct TVPokerBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVTambolaBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVStockPanicBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVMindMeldBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVHotGridBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVSpeedSculptorBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-struct TVWebGameBoardView: View {
-    let room: Room
-    var body: some View { PlaceholderBoardView(game: room.gameID) }
-}
-
-struct PlaceholderBoardView: View {
-    let game: GameID
-    var body: some View {
-        VStack(spacing: 20) {
-            Text(game.emoji).font(.system(size: 80))
-            Text(game.displayName).font(.largeTitle.bold()).foregroundColor(.white)
-            Text("Board coming soon").foregroundColor(.white.opacity(0.4))
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(hex: "0a0a14").ignoresSafeArea())
-    }
-}
+// TV board views are defined in TVClassicGameBoards.swift and TVHeistBoardView.swift
 
 // MARK: - Results views
 
@@ -545,20 +503,38 @@ struct TVResultsView: View {
     let onPlayAgain: () -> Void
 
     var body: some View {
-        VStack(spacing: 32) {
-            Text("Game Over!").font(.system(size: 64, weight: .black)).foregroundColor(.white)
-            let sorted = room.players.sorted { $0.score > $1.score }
-            ForEach(Array(sorted.enumerated()), id: \.element.id) { rank, player in
-                HStack {
-                    Text(rank == 0 ? "🥇" : rank == 1 ? "🥈" : "🥉").font(.title)
-                    Text(player.name).font(.title2).foregroundColor(.white)
-                    Spacer()
-                    Text("\(player.score)").font(.title.bold()).foregroundColor(.cyan)
-                }
-                .padding(.horizontal, 80)
+        VStack(spacing: 40) {
+            VStack(spacing: 8) {
+                Text("🏆 Final Results").font(.system(size: 56, weight: .black)).foregroundColor(.white)
+                Text(room.gameID.displayName).font(.title3).foregroundColor(.white.opacity(0.4))
             }
+
+            let sorted = room.players.sorted { $0.score > $1.score }
+            VStack(spacing: 16) {
+                ForEach(Array(sorted.enumerated()), id: \.element.id) { rank, player in
+                    HStack(spacing: 24) {
+                        Text(rank == 0 ? "🥇" : rank == 1 ? "🥈" : rank == 2 ? "🥉" : "\(rank+1).")
+                            .font(.system(size: 40)).frame(width: 60)
+                        Text(player.name).font(.title2.bold()).foregroundColor(.white)
+                        Spacer()
+                        Text("\(player.score) pts")
+                            .font(.title.bold())
+                            .foregroundColor(rank == 0 ? .yellow : .cyan)
+                    }
+                    .padding(.horizontal, 100)
+                    .padding(.vertical, 16)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(rank == 0 ? Color.yellow.opacity(0.1) : Color.white.opacity(0.05))
+                    )
+                    .padding(.horizontal, 60)
+                }
+            }
+
             Button(action: onPlayAgain) {
-                Text("Play Again").font(.title3.bold()).padding(.horizontal, 60).padding(.vertical, 20)
+                Label("Play Again", systemImage: "arrow.clockwise")
+                    .font(.title3.bold())
+                    .padding(.horizontal, 60).padding(.vertical, 20)
                     .background(RoundedRectangle(cornerRadius: 16).fill(Color.purple))
                     .foregroundColor(.white)
             }
@@ -573,22 +549,79 @@ struct ResultsControllerView: View {
     let room: Room
     let onLeave: () -> Void
 
+    private var myID: String { AppConstants.deviceID }
+    private var sorted: [Player] { room.players.sorted { $0.score > $1.score } }
+    private var myRank: Int {
+        (sorted.firstIndex(where: { $0.id == myID }) ?? 0) + 1
+    }
+
     var body: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            Text("🏁 Game Over!").font(.largeTitle.bold()).foregroundColor(.white)
-            if let me = room.players.first {
-                Text("Your score: \(me.score)").font(.title2).foregroundColor(.cyan)
+        VStack(spacing: 0) {
+            // Header
+            VStack(spacing: 8) {
+                Text("🏁 Game Over").font(.largeTitle.bold()).foregroundColor(.white)
+                Text(room.gameID.displayName).font(.subheadline).foregroundColor(.white.opacity(0.4))
             }
+            .padding(.top, 48).padding(.bottom, 24)
+
+            // My rank callout
+            HStack(spacing: 12) {
+                Text(rankEmoji(myRank)).font(.system(size: 40))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("You finished \(ordinal(myRank))").font(.headline).foregroundColor(.white)
+                    if let me = sorted.first(where: { $0.id == myID }) {
+                        Text("\(me.score) points").font(.subheadline).foregroundColor(.cyan)
+                    }
+                }
+                Spacer()
+            }
+            .padding(16).padding(.horizontal, 24)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.06)))
+            .padding(.horizontal, 24)
+
+            // Full leaderboard
+            ScrollView {
+                VStack(spacing: 8) {
+                    ForEach(Array(sorted.enumerated()), id: \.element.id) { rank, player in
+                        HStack(spacing: 12) {
+                            Text(rankEmoji(rank + 1)).font(.title3).frame(width: 36)
+                            Text(player.name)
+                                .font(.body)
+                                .foregroundColor(player.id == myID ? .cyan : .white)
+                                .fontWeight(player.id == myID ? .bold : .regular)
+                            if player.id == myID {
+                                Text("YOU").font(.caption2.bold()).foregroundColor(.cyan)
+                            }
+                            Spacer()
+                            Text("\(player.score)").font(.headline.bold()).foregroundColor(.white)
+                        }
+                        .padding(.horizontal, 20).padding(.vertical, 12)
+                        .background(RoundedRectangle(cornerRadius: 12)
+                            .fill(player.id == myID ? Color.cyan.opacity(0.1) : Color.white.opacity(0.04)))
+                    }
+                }
+                .padding(.horizontal, 24).padding(.top, 16)
+            }
+
+            Spacer()
+
             Button(action: onLeave) {
-                Text("Back to Lobby").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
-                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.purple))
+                Label("Leave Room", systemImage: "arrow.left.circle")
+                    .font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.white.opacity(0.1)))
                     .foregroundColor(.white)
             }
-            .buttonStyle(.plain).padding(.horizontal, 32)
-            Spacer()
+            .buttonStyle(.plain).padding(.horizontal, 24).padding(.bottom, 40)
         }
         .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func rankEmoji(_ rank: Int) -> String {
+        switch rank { case 1: return "🥇"; case 2: return "🥈"; case 3: return "🥉"; default: return "\(rank)." }
+    }
+
+    private func ordinal(_ n: Int) -> String {
+        switch n { case 1: return "1st"; case 2: return "2nd"; case 3: return "3rd"; default: return "\(n)th" }
     }
 }
 

--- a/ios/GameLabController/Views/Controllers/OtherControllerViews.swift
+++ b/ios/GameLabController/Views/Controllers/OtherControllerViews.swift
@@ -1,0 +1,614 @@
+import SwiftUI
+import CoreMotion
+
+// MARK: - Poker Controller (private hand on phone)
+
+struct PokerControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var hand: [String] { privateData["hand"] as? [String] ?? [] }
+    private var chips: Int { privateData["chips"] as? Int ?? 0 }
+    private var canBet: Bool { (privateData["isMyTurn"] as? Bool) ?? false }
+    @State private var betAmount: Double = 0
+    private var minBet: Int { privateData["minBet"] as? Int ?? 0 }
+    private var maxBet: Int { chips }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Private hand — only you see this
+            VStack(spacing: 12) {
+                HStack(spacing: 6) {
+                    Image(systemName: "eye.slash.fill").foregroundColor(.cyan)
+                    Text("Your Hand (private)").font(.caption).foregroundColor(.cyan)
+                }
+                HStack(spacing: 12) {
+                    ForEach(hand, id: \.self) { card in
+                        CardView(card: card)
+                    }
+                }
+            }
+            .padding(20)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.cyan.opacity(0.08)))
+            .padding(.horizontal, 20)
+
+            Text("Chips: \(chips)").font(.headline).foregroundColor(.white)
+
+            if canBet {
+                VStack(spacing: 16) {
+                    Text("Your Turn").font(.title3.bold()).foregroundColor(.yellow)
+
+                    // Bet slider
+                    VStack(spacing: 8) {
+                        Text("Bet: \(Int(betAmount))").foregroundColor(.white)
+                        Slider(value: $betAmount, in: Double(minBet)...Double(max(maxBet, minBet)))
+                            .tint(.yellow)
+                    }
+                    .padding(.horizontal, 24)
+
+                    HStack(spacing: 12) {
+                        ActionBtn("Fold",  color: .red)    { onAction("fold",  [:]) }
+                        ActionBtn("Check", color: .gray)   { onAction("check", [:]) }
+                        ActionBtn("Bet",   color: .yellow)  { onAction("bet",   ["amount": Int(betAmount)]) }
+                    }
+                    .padding(.horizontal, 20)
+                }
+            } else {
+                Text("Waiting for your turn…")
+                    .foregroundColor(.white.opacity(0.4))
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "001400").ignoresSafeArea())
+        .onAppear { betAmount = Double(minBet) }
+    }
+}
+
+private struct CardView: View {
+    let card: String   // e.g. "A♠", "K♥"
+    private var isRed: Bool { card.contains("♥") || card.contains("♦") }
+    var body: some View {
+        Text(card)
+            .font(.system(size: 28, weight: .bold))
+            .foregroundColor(isRed ? .red : .white)
+            .frame(width: 60, height: 84)
+            .background(RoundedRectangle(cornerRadius: 10).fill(Color.white))
+            .shadow(radius: 4)
+    }
+}
+
+private struct ActionBtn: View {
+    let label: String
+    let color: Color
+    let action: () -> Void
+    init(_ label: String, color: Color, action: @escaping () -> Void) {
+        self.label = label; self.color = color; self.action = action
+    }
+    var body: some View {
+        Button(action: action) {
+            Text(label).font(.headline).foregroundColor(color == .yellow ? .black : .white)
+                .frame(maxWidth: .infinity).padding(.vertical, 14)
+                .background(RoundedRectangle(cornerRadius: 12).fill(color.opacity(0.85)))
+        }.buttonStyle(.plain)
+    }
+}
+
+// MARK: - Snake & Ladder — Shake to Roll
+
+struct ShakeToRollControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var lastRoll: Int? = nil
+    @State private var shakeScale: CGFloat = 1.0
+    private var isMyTurn: Bool { (privateData["isMyTurn"] as? Bool) ?? false }
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            Text("🎲")
+                .font(.system(size: 100))
+                .scaleEffect(shakeScale)
+                .onShake {
+                    guard isMyTurn else { return }
+                    withAnimation(.spring(response: 0.2, dampingFraction: 0.4)) { shakeScale = 1.4 }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        withAnimation(.spring()) { shakeScale = 1.0 }
+                        let roll = Int.random(in: 1...6)
+                        lastRoll = roll
+                        onAction("roll", ["value": roll])
+                    }
+                }
+
+            if let roll = lastRoll {
+                Text("You rolled \(roll)!")
+                    .font(.largeTitle.bold()).foregroundColor(.white)
+            }
+
+            Text(isMyTurn ? "Shake to roll!" : "Not your turn…")
+                .font(.title3)
+                .foregroundColor(isMyTurn ? .cyan : .white.opacity(0.4))
+
+            if let pos = privateData["position"] as? Int {
+                Text("Your position: \(pos)")
+                    .font(.subheadline).foregroundColor(.white.opacity(0.5))
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Pong — Tilt controller
+
+struct PongControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @StateObject private var motion = MotionManager()
+    @State private var lastSent: Date = .distantPast
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Text("🏓 Pong")
+                .font(.largeTitle.bold()).foregroundColor(.white)
+
+            Text("Tilt your phone to move your paddle")
+                .foregroundColor(.white.opacity(0.5))
+
+            // Visual tilt indicator
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.white.opacity(0.06))
+                    .frame(width: 120, height: 300)
+
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.cyan)
+                    .frame(width: 20, height: 60)
+                    .offset(y: CGFloat(motion.roll) * 100)
+            }
+
+            Text("Side: \(privateData["side"] as? String ?? "?")")
+                .font(.caption).foregroundColor(.white.opacity(0.4))
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { motion.start() }
+        .onDisappear { motion.stop() }
+        .onChange(of: motion.roll) { roll in
+            let now = Date()
+            guard now.timeIntervalSince(lastSent) > 0.05 else { return } // 20 fps max
+            lastSent = now
+            onAction("paddle", ["position": roll])
+        }
+    }
+}
+
+@MainActor
+final class MotionManager: ObservableObject {
+    @Published var roll: Double = 0
+    private let manager = CMMotionManager()
+
+    func start() {
+        guard manager.isDeviceMotionAvailable else { return }
+        manager.deviceMotionUpdateInterval = 1.0 / 60.0
+        manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+            guard let motion else { return }
+            self?.roll = max(-1, min(1, motion.attitude.roll / (.pi / 2)))
+        }
+    }
+
+    func stop() { manager.stopDeviceMotionUpdates() }
+}
+
+// MARK: - Mind Meld
+
+struct MindMeldControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var wordInput = ""
+    @State private var hasSubmitted = false
+    private var category: String { privateData["category"] as? String ?? "" }
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            Text("🔮 Mind Meld").font(.largeTitle.bold()).foregroundColor(.white)
+            Text("Category: \(category)").font(.title3).foregroundColor(.cyan)
+            Text("Type ONE word that fits the category.\nTry to match what others think!").font(.subheadline)
+                .foregroundColor(.white.opacity(0.5)).multilineTextAlignment(.center)
+
+            if !hasSubmitted {
+                TextField("Your word…", text: $wordInput)
+                    .font(.title2).foregroundColor(.white).multilineTextAlignment(.center)
+                    .textInputAutocapitalization(.never).autocorrectionDisabled()
+                    .padding(16)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.white.opacity(0.08)))
+                    .padding(.horizontal, 32)
+
+                Button(action: submit) {
+                    Text("Submit").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
+                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.purple))
+                        .foregroundColor(.white)
+                }
+                .buttonStyle(.plain).disabled(wordInput.isEmpty).padding(.horizontal, 32)
+            } else {
+                Image(systemName: "brain.filled.head.profile").font(.system(size: 60)).foregroundColor(.purple)
+                Text("Word submitted!\nWatch the TV for the meld…").font(.title3).foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+            }
+            Spacer()
+        }
+        .background(Color(hex: "0d0a14").ignoresSafeArea())
+    }
+
+    private func submit() {
+        guard !wordInput.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        hasSubmitted = true
+        onAction("word", ["word": wordInput.trimmingCharacters(in: .whitespaces).lowercased()])
+    }
+}
+
+// MARK: - Hot Grid
+
+struct HotGridControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var hasPicked = false
+    private var isMyTurn: Bool { (privateData["isMyTurn"] as? Bool) ?? false }
+    private let gridSize = 5
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("💣 Hot Grid").font(.largeTitle.bold()).foregroundColor(.white)
+            Text(isMyTurn ? "Pick a tile!" : "Waiting for your turn…")
+                .font(.title3).foregroundColor(isMyTurn ? .yellow : .white.opacity(0.4))
+
+            if isMyTurn && !hasPicked {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: gridSize), spacing: 12) {
+                    ForEach(0..<gridSize*gridSize, id: \.self) { idx in
+                        Button(action: { pick(idx) }) {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.white.opacity(0.1))
+                                .frame(height: 52)
+                                .overlay(Text("?").font(.title2).foregroundColor(.white.opacity(0.5)))
+                        }.buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+            Spacer()
+        }
+        .padding(.top, 40)
+        .background(Color(hex: "0a0a0a").ignoresSafeArea())
+    }
+
+    private func pick(_ index: Int) {
+        hasPicked = true
+        onAction("pick_tile", ["index": index])
+    }
+}
+
+// MARK: - Stock Panic
+
+struct StockPanicControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var portfolio: [String: Int] { privateData["portfolio"] as? [String: Int] ?? [:] }
+    private var cash: Int { privateData["cash"] as? Int ?? 0 }
+    private var stocks: [String] { portfolio.keys.sorted() }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                Text("📈 Stock Panic").font(.title.bold()).foregroundColor(.white)
+                Text("Cash: $\(cash)").font(.headline).foregroundColor(.green)
+
+                ForEach(stocks, id: \.self) { stock in
+                    HStack(spacing: 16) {
+                        Text(stock).font(.headline).foregroundColor(.white).frame(width: 80)
+                        Text("×\(portfolio[stock] ?? 0)").foregroundColor(.white.opacity(0.6))
+                        Spacer()
+                        Button("Buy") { onAction("trade", ["stock": stock, "action": "buy"]) }
+                            .foregroundColor(.green).padding(.horizontal, 14).padding(.vertical, 8)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(Color.green.opacity(0.2)))
+                            .buttonStyle(.plain)
+                        Button("Sell") { onAction("trade", ["stock": stock, "action": "sell"]) }
+                            .foregroundColor(.red).padding(.horizontal, 14).padding(.vertical, 8)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(Color.red.opacity(0.2)))
+                            .buttonStyle(.plain)
+                    }
+                    .padding(14)
+                    .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.06)))
+                }
+            }
+            .padding(24)
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Speed Sculptor (drawing canvas)
+
+struct SpeedSculptorControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var lines: [DrawLine] = []
+    @State private var currentLine: DrawLine? = nil
+    @State private var submitted = false
+    private var prompt: String { privateData["prompt"] as? String ?? "?" }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("🎨 Draw: \(prompt)").font(.headline).foregroundColor(.white)
+                Spacer()
+                Button("Clear") { lines = []; currentLine = nil }
+                    .foregroundColor(.cyan).buttonStyle(.plain)
+            }
+            .padding(16)
+            .background(Color.white.opacity(0.06))
+
+            // Drawing canvas
+            Canvas { ctx, size in
+                for line in lines {
+                    var path = Path()
+                    guard let first = line.points.first else { continue }
+                    path.move(to: first)
+                    for pt in line.points.dropFirst() { path.addLine(to: pt) }
+                    ctx.stroke(path, with: .color(line.color), style: .init(lineWidth: line.width, lineCap: .round, lineJoin: .round))
+                }
+                if let current = currentLine {
+                    var path = Path()
+                    guard let first = current.points.first else { return }
+                    path.move(to: first)
+                    for pt in current.points.dropFirst() { path.addLine(to: pt) }
+                    ctx.stroke(path, with: .color(current.color), style: .init(lineWidth: current.width, lineCap: .round, lineJoin: .round))
+                }
+            }
+            .background(Color.white)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        if currentLine == nil {
+                            currentLine = DrawLine(points: [value.location], color: .black, width: 4)
+                        } else {
+                            currentLine?.points.append(value.location)
+                        }
+                    }
+                    .onEnded { _ in
+                        if let line = currentLine { lines.append(line) }
+                        currentLine = nil
+                    }
+            )
+
+            if !submitted {
+                Button(action: submitDrawing) {
+                    Text("Submit Drawing").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
+                        .background(RoundedRectangle(cornerRadius: 14).fill(Color.purple))
+                        .foregroundColor(.white)
+                }
+                .buttonStyle(.plain).padding(16)
+            } else {
+                Text("✓ Submitted! Watch the TV.").foregroundColor(.green).padding(16)
+            }
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+
+    private func submitDrawing() {
+        submitted = true
+        // Encode lines as simplified point arrays for server
+        let encoded = lines.map { line in
+            line.points.map { ["x": $0.x, "y": $0.y] }
+        }
+        onAction("drawing", ["lines": encoded, "prompt": prompt])
+    }
+}
+
+struct DrawLine {
+    var points: [CGPoint]
+    let color: Color
+    let width: CGFloat
+}
+
+// MARK: - Tambola (Bingo ticket)
+
+struct TambolaControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    private var ticket: [[Int?]] { (privateData["ticket"] as? [[Int?]]) ?? [] }
+    private var markedNumbers: Set<Int> {
+        Set((privateData["marked"] as? [Int]) ?? [])
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("🎱 Tambola").font(.title.bold()).foregroundColor(.white)
+            Text("Your Ticket").font(.subheadline).foregroundColor(.white.opacity(0.4))
+
+            VStack(spacing: 6) {
+                ForEach(Array(ticket.enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 6) {
+                        ForEach(Array(row.enumerated()), id: \.offset) { _, num in
+                            if let n = num {
+                                Button(action: { onAction("mark", ["number": n]) }) {
+                                    Text("\(n)").font(.system(.body, design: .monospaced).bold())
+                                        .frame(width: 40, height: 40)
+                                        .background(RoundedRectangle(cornerRadius: 8)
+                                            .fill(markedNumbers.contains(n) ? Color.green.opacity(0.4) : Color.white.opacity(0.1)))
+                                        .foregroundColor(.white)
+                                }
+                                .buttonStyle(.plain)
+                            } else {
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.white.opacity(0.03))
+                                    .frame(width: 40, height: 40)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Button(action: { onAction("claim", ["type": "full_house"]) }) {
+                Text("🎉 Claim Full House!").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 14)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.yellow.opacity(0.85)))
+                    .foregroundColor(.black)
+            }
+            .buttonStyle(.plain).padding(.horizontal, 24)
+
+            Spacer()
+        }
+        .padding(.top, 40)
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Generic tap controller (fallback)
+
+struct GenericTapControllerView: View {
+    let room: Room
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Text(room.gameID.emoji).font(.system(size: 72))
+            Text(room.gameID.displayName).font(.title.bold()).foregroundColor(.white)
+            Text("Game in progress").foregroundColor(.white.opacity(0.4))
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Placeholder board views (TV side, other games)
+
+struct TVPokerBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVTambolaBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVStockPanicBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVMindMeldBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVHotGridBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVSpeedSculptorBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+struct TVWebGameBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+
+struct PlaceholderBoardView: View {
+    let game: GameID
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(game.emoji).font(.system(size: 80))
+            Text(game.displayName).font(.largeTitle.bold()).foregroundColor(.white)
+            Text("Board coming soon").foregroundColor(.white.opacity(0.4))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Results views
+
+struct TVResultsView: View {
+    let room: Room
+    let onPlayAgain: () -> Void
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Text("Game Over!").font(.system(size: 64, weight: .black)).foregroundColor(.white)
+            let sorted = room.players.sorted { $0.score > $1.score }
+            ForEach(Array(sorted.enumerated()), id: \.element.id) { rank, player in
+                HStack {
+                    Text(rank == 0 ? "🥇" : rank == 1 ? "🥈" : "🥉").font(.title)
+                    Text(player.name).font(.title2).foregroundColor(.white)
+                    Spacer()
+                    Text("\(player.score)").font(.title.bold()).foregroundColor(.cyan)
+                }
+                .padding(.horizontal, 80)
+            }
+            Button(action: onPlayAgain) {
+                Text("Play Again").font(.title3.bold()).padding(.horizontal, 60).padding(.vertical, 20)
+                    .background(RoundedRectangle(cornerRadius: 16).fill(Color.purple))
+                    .foregroundColor(.white)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+struct ResultsControllerView: View {
+    let room: Room
+    let onLeave: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Text("🏁 Game Over!").font(.largeTitle.bold()).foregroundColor(.white)
+            if let me = room.players.first {
+                Text("Your score: \(me.score)").font(.title2).foregroundColor(.cyan)
+            }
+            Button(action: onLeave) {
+                Text("Back to Lobby").font(.headline).frame(maxWidth: .infinity).padding(.vertical, 16)
+                    .background(RoundedRectangle(cornerRadius: 14).fill(Color.purple))
+                    .foregroundColor(.white)
+            }
+            .buttonStyle(.plain).padding(.horizontal, 32)
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+// MARK: - Shake gesture
+
+extension View {
+    func onShake(perform action: @escaping () -> Void) -> some View {
+        self.modifier(ShakeDetector(action: action))
+    }
+}
+
+struct ShakeDetector: ViewModifier {
+    let action: () -> Void
+    func body(content: Content) -> some View {
+        content.onReceive(NotificationCenter.default.publisher(for: .deviceDidShakeNotification)) { _ in
+            action()
+        }
+    }
+}
+
+extension Notification.Name {
+    static let deviceDidShakeNotification = Notification.Name("DeviceDidShake")
+}

--- a/ios/GameLabController/Views/Controllers/TriviaControllerView.swift
+++ b/ios/GameLabController/Views/Controllers/TriviaControllerView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Trivia phone controller — big tap buttons, race to answer first.
+struct TriviaControllerView: View {
+    let privateData: [String: Any]
+    let onAction: (String, [String: Any]) -> Void
+
+    @State private var selectedIndex: Int? = nil
+    @State private var questionID: String = ""
+
+    private var choices: [String] {
+        privateData["choices"] as? [String] ?? []
+    }
+
+    private var currentQuestionID: String {
+        privateData["questionID"] as? String ?? ""
+    }
+
+    private var hasAnswered: Bool { selectedIndex != nil }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("🧠 Trivia")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Spacer()
+                if let score = privateData["score"] as? Int {
+                    Text("Score: \(score)")
+                        .font(.subheadline.bold())
+                        .foregroundColor(.cyan)
+                }
+            }
+            .padding(20)
+            .background(Color.white.opacity(0.04))
+
+            Spacer()
+
+            if !hasAnswered {
+                VStack(spacing: 16) {
+                    Text("Tap your answer!")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.4))
+
+                    ForEach(Array(choices.enumerated()), id: \.offset) { idx, choice in
+                        AnswerButton(label: choice, index: idx, state: .idle) {
+                            submit(index: idx)
+                        }
+                    }
+                }
+                .padding(.horizontal, 24)
+            } else {
+                VStack(spacing: 20) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 56))
+                        .foregroundColor(.green)
+                    Text("Answer submitted!")
+                        .font(.title3.bold())
+                        .foregroundColor(.white)
+                    Text("Watch the TV for results")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onChange(of: currentQuestionID) { newID in
+            // New question — reset answer state
+            if newID != questionID {
+                selectedIndex = nil
+                questionID = newID
+            }
+        }
+        .onAppear { questionID = currentQuestionID }
+    }
+
+    private func submit(index: Int) {
+        guard !hasAnswered else { return }
+        selectedIndex = index
+        onAction("answer", ["choiceIndex": index, "questionID": questionID])
+    }
+}
+
+// MARK: - Answer button
+
+struct AnswerButton: View {
+    enum AnswerState { case idle, selected, correct, wrong }
+
+    let label: String
+    let index: Int
+    let state: AnswerState
+    let action: () -> Void
+
+    private let letters = ["A", "B", "C", "D"]
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 16) {
+                Text(letters[min(index, 3)])
+                    .font(.headline.bold())
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(letterBG))
+                    .foregroundColor(.white)
+
+                Text(label)
+                    .font(.body)
+                    .foregroundColor(.white)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .multilineTextAlignment(.leading)
+
+                Spacer()
+            }
+            .padding(18)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(tileBG)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(tileBorder, lineWidth: 1.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(state == .selected ? 0.97 : 1.0)
+        .animation(.spring(response: 0.2), value: state)
+    }
+
+    private var letterBG: Color {
+        switch state {
+        case .idle:     return Color.white.opacity(0.15)
+        case .selected: return Color.cyan
+        case .correct:  return Color.green
+        case .wrong:    return Color.red
+        }
+    }
+
+    private var tileBG: Color {
+        switch state {
+        case .idle:     return Color.white.opacity(0.06)
+        case .selected: return Color.cyan.opacity(0.1)
+        case .correct:  return Color.green.opacity(0.1)
+        case .wrong:    return Color.red.opacity(0.08)
+        }
+    }
+
+    private var tileBorder: Color {
+        switch state {
+        case .idle:     return Color.white.opacity(0.08)
+        case .selected: return Color.cyan.opacity(0.5)
+        case .correct:  return Color.green.opacity(0.7)
+        case .wrong:    return Color.red.opacity(0.5)
+        }
+    }
+}

--- a/ios/GameLabController/Views/JoinRoomView.swift
+++ b/ios/GameLabController/Views/JoinRoomView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct JoinRoomView: View {
+    let onJoin: (String, String) -> Void
+
+    @State private var code = ""
+    @State private var name = ""
+    @State private var shakeCode = false
+    @FocusState private var focusedField: Field?
+
+    private enum Field { case code, name }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 40) {
+                // Logo
+                VStack(spacing: 6) {
+                    Text("🎮")
+                        .font(.system(size: 64))
+                    Text("GameLab")
+                        .font(.system(size: 36, weight: .black, design: .rounded))
+                        .foregroundStyle(
+                            LinearGradient(colors: [.purple, .cyan],
+                                           startPoint: .leading, endPoint: .trailing)
+                        )
+                    Text("Your phone is the controller")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.top, 60)
+
+                // Input fields
+                VStack(spacing: 16) {
+                    // Room code — large, prominent
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Room Code")
+                            .font(.caption.bold())
+                            .foregroundColor(.white.opacity(0.5))
+                            .tracking(2)
+
+                        TextField("", text: $code)
+                            .placeholder(when: code.isEmpty) {
+                                Text("ABC123").foregroundColor(.white.opacity(0.2))
+                            }
+                            .font(.system(size: 36, weight: .bold, design: .monospaced))
+                            .multilineTextAlignment(.center)
+                            .textInputAutocapitalization(.characters)
+                            .autocorrectionDisabled()
+                            .foregroundColor(.white)
+                            .focused($focusedField, equals: .code)
+                            .onChange(of: code) { code = String($0.prefix(6).uppercased()) }
+                            .frame(height: 64)
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(Color.white.opacity(0.06))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 16)
+                                            .strokeBorder(
+                                                shakeCode ? Color.red : Color.white.opacity(0.1),
+                                                lineWidth: 1.5
+                                            )
+                                    )
+                            )
+                            .offset(x: shakeCode ? 6 : 0)
+                            .animation(shakeCode ? .default.repeatCount(4, autoreverses: true).speed(8) : .default,
+                                       value: shakeCode)
+                    }
+
+                    // Name field
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Your Name")
+                            .font(.caption.bold())
+                            .foregroundColor(.white.opacity(0.5))
+                            .tracking(2)
+
+                        TextField("", text: $name)
+                            .placeholder(when: name.isEmpty) {
+                                Text("Enter name").foregroundColor(.white.opacity(0.2))
+                            }
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .focused($focusedField, equals: .name)
+                            .onChange(of: name) { name = String($0.prefix(20)) }
+                            .frame(height: 54)
+                            .padding(.horizontal, 16)
+                            .background(
+                                RoundedRectangle(cornerRadius: 14)
+                                    .fill(Color.white.opacity(0.06))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 14)
+                                            .strokeBorder(Color.white.opacity(0.1), lineWidth: 1.5)
+                                    )
+                            )
+                    }
+                }
+                .padding(.horizontal, 32)
+
+                // Join button
+                Button(action: attemptJoin) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "arrow.right.circle.fill")
+                        Text("Join Game")
+                            .font(.headline)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(
+                                canJoin
+                                ? LinearGradient(colors: [.purple, .cyan],
+                                                 startPoint: .leading, endPoint: .trailing)
+                                : LinearGradient(colors: [Color.white.opacity(0.1)],
+                                                 startPoint: .leading, endPoint: .trailing)
+                            )
+                    )
+                    .foregroundColor(canJoin ? .white : .white.opacity(0.3))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canJoin)
+                .padding(.horizontal, 32)
+                .padding(.bottom, 40)
+            }
+        }
+        .onTapGesture { focusedField = nil }
+    }
+
+    private var canJoin: Bool { code.count == 6 && !name.trimmingCharacters(in: .whitespaces).isEmpty }
+
+    private func attemptJoin() {
+        guard canJoin else { triggerShake(); return }
+        onJoin(code, name.trimmingCharacters(in: .whitespaces))
+    }
+
+    private func triggerShake() {
+        shakeCode = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { shakeCode = false }
+    }
+}
+
+// MARK: - Placeholder helper
+
+extension View {
+    func placeholder<C: View>(when show: Bool, @ViewBuilder placeholder: () -> C) -> some View {
+        ZStack(alignment: .center) {
+            if show { placeholder() }
+            self
+        }
+    }
+}

--- a/ios/GameLabController/Views/WaitingView.swift
+++ b/ios/GameLabController/Views/WaitingView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct WaitingView: View {
+    let room: Room
+    let onReady: () -> Void
+
+    @State private var isReady = false
+
+    var body: some View {
+        VStack(spacing: 36) {
+            Spacer()
+
+            // Game badge
+            VStack(spacing: 12) {
+                Text(room.gameID.emoji)
+                    .font(.system(size: 72))
+                Text(room.gameID.displayName)
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            // Room code (small reference)
+            HStack(spacing: 8) {
+                Text("Room")
+                    .foregroundColor(.white.opacity(0.4))
+                Text(room.code)
+                    .font(.system(.body, design: .monospaced).bold())
+                    .foregroundColor(.cyan)
+            }
+
+            // Player list
+            VStack(spacing: 10) {
+                ForEach(room.players) { player in
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(player.isReady ? Color.green.opacity(0.3) : Color.white.opacity(0.1))
+                            .frame(width: 32, height: 32)
+                            .overlay(Text(String(player.name.prefix(1))).foregroundColor(.white).font(.caption.bold()))
+
+                        Text(player.name)
+                            .foregroundColor(.white)
+
+                        if player.isHost { Text("HOST").font(.caption2).foregroundColor(.cyan) }
+
+                        Spacer()
+
+                        Image(systemName: player.isReady ? "checkmark.circle.fill" : "circle")
+                            .foregroundColor(player.isReady ? .green : .white.opacity(0.2))
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.05)))
+                }
+            }
+            .padding(.horizontal, 24)
+
+            // Private info note
+            if room.gameID.hasPrivateInfo {
+                HStack(spacing: 8) {
+                    Image(systemName: "eye.slash.fill")
+                    Text("Your private info will appear here when the game starts")
+                        .font(.caption)
+                }
+                .foregroundColor(.cyan.opacity(0.7))
+                .padding(.horizontal, 32)
+            }
+
+            Spacer()
+
+            // Ready button
+            Button(action: {
+                isReady = true
+                onReady()
+            }) {
+                HStack(spacing: 8) {
+                    Image(systemName: isReady ? "checkmark.circle.fill" : "hand.thumbsup.fill")
+                    Text(isReady ? "Ready!" : "I'm Ready")
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(isReady ? Color.green.opacity(0.3) : Color.cyan)
+                )
+                .foregroundColor(.white)
+            }
+            .buttonStyle(.plain)
+            .disabled(isReady)
+            .padding(.horizontal, 32)
+            .padding(.bottom, 40)
+        }
+    }
+}

--- a/ios/GameLabTV/App/GameLabTVApp.swift
+++ b/ios/GameLabTV/App/GameLabTVApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct GameLabTVApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootTVView()
+                .onAppear {
+                    GameSocketManager.shared.connect(to: AppConstants.serverURL)
+                }
+        }
+    }
+}

--- a/ios/GameLabTV/App/RootTVView.swift
+++ b/ios/GameLabTV/App/RootTVView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct RootTVView: View {
+    @StateObject private var vm = TVRootViewModel()
+
+    var body: some View {
+        ZStack {
+            // Background gradient — persists across all screens
+            LinearGradient(
+                colors: [Color(hex: "0d0d1a"), Color(hex: "1a0d2e")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            switch vm.screen {
+            case .gameSelection:
+                TVGameSelectionView(onSelect: vm.createRoom)
+
+            case .lobby(let room):
+                TVLobbyView(room: room, onStart: vm.startGame)
+
+            case .playing(let room):
+                TVGameBoardView(room: room)
+
+            case .results(let room):
+                TVResultsView(room: room, onPlayAgain: vm.returnToSelection)
+            }
+        }
+        .environmentObject(vm)
+    }
+}
+
+// MARK: - View Model
+
+enum TVScreen {
+    case gameSelection
+    case lobby(Room)
+    case playing(Room)
+    case results(Room)
+}
+
+@MainActor
+final class TVRootViewModel: ObservableObject {
+    @Published var screen: TVScreen = .gameSelection
+
+    private let socket = GameSocketManager.shared
+
+    init() {
+        socket.on(.roomUpdated) { [weak self] (response: Room) in
+            guard let self else { return }
+            switch response.state {
+            case .lobby:   self.screen = .lobby(response)
+            case .playing: self.screen = .playing(response)
+            case .results: self.screen = .results(response)
+            }
+        }
+    }
+
+    func createRoom(game: GameID) {
+        let payload = CreateRoomPayload(
+            gameID: game.rawValue,
+            hostName: "TV",
+            hostID: AppConstants.deviceID
+        )
+        socket.emit(.createRoom, payload: payload)
+    }
+
+    func startGame() {
+        guard case .lobby(let room) = screen else { return }
+        socket.emit(.startGame, payload: ["roomCode": room.code])
+    }
+
+    func returnToSelection() {
+        screen = .gameSelection
+    }
+}

--- a/ios/GameLabTV/Info.plist
+++ b/ios/GameLabTV/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>GameLab TV connects to the game server on your local network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_gamelab._tcp</string>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/ios/GameLabTV/Views/Games/TVClassicGameBoards.swift
+++ b/ios/GameLabTV/Views/Games/TVClassicGameBoards.swift
@@ -1,0 +1,1473 @@
+import SwiftUI
+
+// MARK: - Shared helpers
+
+struct PlaceholderBoardView: View {
+    let game: GameID
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(game.emoji).font(.system(size: 80))
+            Text(game.displayName).font(.largeTitle.bold()).foregroundColor(.white)
+            Text("Coming soon").foregroundColor(.white.opacity(0.4))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+    }
+}
+
+struct TVWebGameBoardView: View {
+    let room: Room
+    var body: some View { PlaceholderBoardView(game: room.gameID) }
+}
+
+// Shared score header used by multiple board views
+private struct TVScoreHeader: View {
+    let players: [Player]
+    let currentPlayerID: String?
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ForEach(players) { p in
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(p.id == currentPlayerID ? Color.cyan : Color.white.opacity(0.15))
+                        .frame(width: 12, height: 12)
+                    Text(p.name).foregroundColor(p.id == currentPlayerID ? .white : .white.opacity(0.5))
+                    Text("\(p.score)").font(.headline.bold()).foregroundColor(.cyan)
+                }
+                .padding(.horizontal, 14).padding(.vertical, 8)
+                .background(Capsule().fill(p.id == currentPlayerID ? Color.cyan.opacity(0.15) : Color.white.opacity(0.05)))
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 48)
+    }
+}
+
+// MARK: - Pong Board
+
+struct TVPongBoardView: View {
+    let room: Room
+    @StateObject private var vm = PongBoardViewModel()
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            // Centre divider
+            VStack(spacing: 8) {
+                ForEach(0..<12, id: \.self) { _ in
+                    Rectangle().fill(Color.white.opacity(0.3)).frame(width: 4, height: 24)
+                }
+            }
+
+            // Left paddle
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.white)
+                .frame(width: 12, height: 80)
+                .position(x: 60, y: paddleY(vm.state.leftPaddlePos))
+
+            // Right paddle
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.white)
+                .frame(width: 12, height: 80)
+                .position(x: UIScreen.main.bounds.width - 60, y: paddleY(vm.state.rightPaddlePos))
+
+            // Ball
+            Circle().fill(Color.white).frame(width: 20, height: 20)
+                .position(x: vm.state.ballX * UIScreen.main.bounds.width,
+                          y: vm.state.ballY * UIScreen.main.bounds.height)
+                .shadow(color: .cyan, radius: 8)
+
+            // Scores
+            HStack {
+                Text("\(vm.state.scoreLeft)")
+                    .font(.system(size: 72, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.4))
+                Spacer()
+                Text("\(vm.state.scoreRight)")
+                    .font(.system(size: 72, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+            .padding(.horizontal, 120)
+            .frame(maxHeight: .infinity, alignment: .top)
+            .padding(.top, 60)
+
+            // Player labels
+            HStack {
+                Text(vm.state.leftPlayerName).font(.title3).foregroundColor(.white.opacity(0.4))
+                Spacer()
+                Text(vm.state.rightPlayerName).font(.title3).foregroundColor(.white.opacity(0.4))
+            }
+            .padding(.horizontal, 60)
+            .frame(maxHeight: .infinity, alignment: .bottom)
+            .padding(.bottom, 40)
+        }
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+
+    private func paddleY(_ normalized: Double) -> CGFloat {
+        CGFloat(normalized) * UIScreen.main.bounds.height
+    }
+}
+
+struct PongState {
+    var ballX: Double = 0.5
+    var ballY: Double = 0.5
+    var leftPaddlePos: Double = 0.5
+    var rightPaddlePos: Double = 0.5
+    var scoreLeft = 0
+    var scoreRight = 0
+    var leftPlayerName = "Player 1"
+    var rightPlayerName = "Player 2"
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["ballX"]?.value as? Double          { ballX = v }
+        if let v = data["ballY"]?.value as? Double          { ballY = v }
+        if let v = data["leftPaddle"]?.value as? Double     { leftPaddlePos = v }
+        if let v = data["rightPaddle"]?.value as? Double    { rightPaddlePos = v }
+        if let v = data["scoreLeft"]?.value as? Int         { scoreLeft = v }
+        if let v = data["scoreRight"]?.value as? Int        { scoreRight = v }
+        if let v = data["leftName"]?.value as? String       { leftPlayerName = v }
+        if let v = data["rightName"]?.value as? String      { rightPlayerName = v }
+    }
+}
+
+@MainActor final class PongBoardViewModel: ObservableObject {
+    @Published var state = PongState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Poker Board
+
+struct TVPokerBoardView: View {
+    let room: Room
+    @StateObject private var vm = PokerBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            // Phase + pot
+            HStack(spacing: 32) {
+                VStack(spacing: 4) {
+                    Text(vm.state.phase.uppercased()).font(.caption.bold()).tracking(3)
+                        .foregroundColor(.yellow.opacity(0.7))
+                    Text("🃏 Poker").font(.title2.bold()).foregroundColor(.white)
+                }
+                Spacer()
+                VStack(spacing: 4) {
+                    Text("POT").font(.caption.bold()).tracking(2).foregroundColor(.white.opacity(0.4))
+                    Text("$\(vm.state.pot)").font(.system(size: 36, weight: .bold)).foregroundColor(.yellow)
+                }
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            // Community cards
+            VStack(spacing: 12) {
+                Text("Community Cards").font(.subheadline).foregroundColor(.white.opacity(0.4))
+                HStack(spacing: 16) {
+                    ForEach(0..<5, id: \.self) { idx in
+                        if idx < vm.state.communityCards.count {
+                            TVCardView(card: vm.state.communityCards[idx])
+                        } else {
+                            TVCardBack()
+                        }
+                    }
+                }
+            }
+
+            // Player seats around table
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: min(room.players.count, 4)),
+                      spacing: 20) {
+                ForEach(vm.state.playerSeats) { seat in
+                    PokerSeatView(seat: seat)
+                }
+            }
+            .padding(.horizontal, 60)
+
+            Spacer()
+        }
+        .background(Color(hex: "001a00").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+private struct TVCardView: View {
+    let card: String
+    private var isRed: Bool { card.contains("♥") || card.contains("♦") }
+    var body: some View {
+        Text(card)
+            .font(.system(size: 32, weight: .bold))
+            .foregroundColor(isRed ? .red : .black)
+            .frame(width: 70, height: 100)
+            .background(RoundedRectangle(cornerRadius: 10).fill(Color.white))
+            .shadow(radius: 4)
+    }
+}
+
+private struct TVCardBack: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color(hex: "1a0a2e"))
+            .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.purple.opacity(0.4), lineWidth: 1))
+            .frame(width: 70, height: 100)
+            .overlay(Text("🂠").font(.system(size: 40)))
+    }
+}
+
+struct PokerSeat: Identifiable {
+    let id: String
+    let name: String
+    let chips: Int
+    let currentBet: Int
+    let status: String  // "active", "folded", "all-in", "waiting"
+    let isCurrentTurn: Bool
+}
+
+struct PokerBoardState {
+    var communityCards: [String] = []
+    var pot = 0
+    var phase = "pre-flop"
+    var playerSeats: [PokerSeat] = []
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["pot"]?.value as? Int             { pot = v }
+        if let v = data["phase"]?.value as? String        { phase = v }
+        if let v = data["communityCards"]?.value as? [String] { communityCards = v }
+        if let seats = data["players"]?.value as? [[String: Any]] {
+            playerSeats = seats.compactMap { d -> PokerSeat? in
+                guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+                return PokerSeat(id: id, name: name,
+                                 chips: d["chips"] as? Int ?? 0,
+                                 currentBet: d["currentBet"] as? Int ?? 0,
+                                 status: d["status"] as? String ?? "waiting",
+                                 isCurrentTurn: d["isCurrentTurn"] as? Bool ?? false)
+            }
+        }
+    }
+}
+
+@MainActor final class PokerBoardViewModel: ObservableObject {
+    @Published var state = PokerBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+private struct PokerSeatView: View {
+    let seat: PokerSeat
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(seat.name).font(.headline)
+                .foregroundColor(seat.isCurrentTurn ? .yellow : .white)
+            Text("$\(seat.chips)").font(.subheadline).foregroundColor(.green)
+            if seat.currentBet > 0 {
+                Text("Bet: $\(seat.currentBet)").font(.caption).foregroundColor(.cyan)
+            }
+            Text(seat.status).font(.caption2.bold())
+                .foregroundColor(statusColor(seat.status))
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 14)
+            .fill(seat.isCurrentTurn ? Color.yellow.opacity(0.1) : Color.white.opacity(0.05))
+            .overlay(RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(seat.isCurrentTurn ? Color.yellow.opacity(0.5) : Color.clear, lineWidth: 2)))
+    }
+    private func statusColor(_ s: String) -> Color {
+        switch s { case "active": return .white; case "folded": return .red.opacity(0.6);
+                   case "all-in": return .orange; default: return .white.opacity(0.3) }
+    }
+}
+
+// MARK: - Connect 4 Board
+
+struct TVConnect4BoardView: View {
+    let room: Room
+    @StateObject private var vm = Connect4BoardViewModel()
+
+    private let rows = 6, cols = 7
+
+    var body: some View {
+        VStack(spacing: 24) {
+            TVScoreHeader(players: room.players, currentPlayerID: vm.state.currentPlayerID)
+                .padding(.top, 40)
+
+            Text("🟡 Connect 4").font(.largeTitle.bold()).foregroundColor(.white)
+
+            if let winner = vm.state.winner {
+                Text("\(winner) wins! 🎉").font(.title2.bold()).foregroundColor(.yellow)
+            } else {
+                Text(vm.state.currentPlayerName.isEmpty ? "" : "\(vm.state.currentPlayerName)'s turn")
+                    .font(.title3).foregroundColor(.white.opacity(0.6))
+            }
+
+            // Grid
+            VStack(spacing: 6) {
+                ForEach(0..<rows, id: \.self) { row in
+                    HStack(spacing: 6) {
+                        ForEach(0..<cols, id: \.self) { col in
+                            let cell = vm.state.grid[row][col]
+                            let isWin = vm.state.winCells.contains("\(row),\(col)")
+                            Circle()
+                                .fill(cellColor(cell))
+                                .frame(width: 72, height: 72)
+                                .shadow(color: isWin ? .yellow : .clear, radius: 10)
+                                .scaleEffect(isWin ? 1.1 : 1.0)
+                                .animation(.spring(), value: isWin)
+                        }
+                    }
+                }
+            }
+            .padding(20)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color(hex: "001a3a")))
+
+            Spacer()
+        }
+        .background(Color(hex: "000814").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+
+    private func cellColor(_ cell: String) -> Color {
+        switch cell { case "red": return .red; case "yellow": return .yellow;
+                      default: return Color(hex: "0a1a2e") }
+    }
+}
+
+struct Connect4BoardState {
+    var grid: [[String]] = Array(repeating: Array(repeating: "", count: 7), count: 6)
+    var currentPlayerID = ""
+    var currentPlayerName = ""
+    var winner: String? = nil
+    var winCells: Set<String> = []
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let g = data["grid"]?.value as? [[String]]  { grid = g }
+        if let v = data["currentPlayerID"]?.value as? String  { currentPlayerID = v }
+        if let v = data["currentPlayerName"]?.value as? String { currentPlayerName = v }
+        if let v = data["winner"]?.value as? String    { winner = v }
+        if let v = data["winCells"]?.value as? [String] { winCells = Set(v) }
+    }
+}
+
+@MainActor final class Connect4BoardViewModel: ObservableObject {
+    @Published var state = Connect4BoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Memory Board
+
+struct TVMemoryBoardView: View {
+    let room: Room
+    @StateObject private var vm = MemoryBoardViewModel()
+
+    private let cols = 4
+
+    var body: some View {
+        VStack(spacing: 24) {
+            TVScoreHeader(players: room.players, currentPlayerID: vm.state.currentPlayerID)
+                .padding(.top, 40)
+
+            Text("🧩 Memory").font(.largeTitle.bold()).foregroundColor(.white)
+
+            Text(vm.state.currentPlayerName.isEmpty ? "" : "\(vm.state.currentPlayerName)'s turn")
+                .font(.title3).foregroundColor(.white.opacity(0.5))
+
+            LazyVGrid(columns: Array(repeating: GridItem(.fixed(120), spacing: 16), count: cols), spacing: 16) {
+                ForEach(Array(vm.state.cards.enumerated()), id: \.offset) { idx, card in
+                    TVMemoryCard(card: card)
+                }
+            }
+            .padding(32)
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct MemoryCard: Identifiable {
+    let id: Int
+    var value: String
+    var state: MemoryCardState  // hidden, flipped, matched
+}
+
+enum MemoryCardState: String { case hidden, flipped, matched }
+
+private struct TVMemoryCard: View {
+    let card: MemoryCard
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(card.state == .matched ? Color.green.opacity(0.25)
+                      : card.state == .flipped ? Color.white.opacity(0.15)
+                      : Color(hex: "1e1e3a"))
+                .overlay(RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(card.state == .matched ? Color.green.opacity(0.5) : Color.white.opacity(0.06),
+                                  lineWidth: 2))
+                .frame(width: 112, height: 112)
+
+            if card.state != .hidden {
+                Text(card.value).font(.system(size: 48))
+            } else {
+                Image(systemName: "questionmark").font(.system(size: 32))
+                    .foregroundColor(.white.opacity(0.2))
+            }
+        }
+        .rotation3DEffect(
+            .degrees(card.state == .hidden ? 0 : 180),
+            axis: (x: 0, y: 1, z: 0)
+        )
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: card.state)
+    }
+}
+
+struct MemoryBoardState {
+    var cards: [MemoryCard] = []
+    var currentPlayerID = ""
+    var currentPlayerName = ""
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["currentPlayerID"]?.value as? String   { currentPlayerID = v }
+        if let v = data["currentPlayerName"]?.value as? String { currentPlayerName = v }
+        if let rawCards = data["cards"]?.value as? [[String: Any]] {
+            cards = rawCards.enumerated().compactMap { idx, d -> MemoryCard? in
+                let stateStr = d["state"] as? String ?? "hidden"
+                return MemoryCard(
+                    id: idx,
+                    value: d["value"] as? String ?? "?",
+                    state: MemoryCardState(rawValue: stateStr) ?? .hidden
+                )
+            }
+        }
+    }
+}
+
+@MainActor final class MemoryBoardViewModel: ObservableObject {
+    @Published var state = MemoryBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Mafia Board
+
+struct TVMafiaBoardView: View {
+    let room: Room
+    @StateObject private var vm = MafiaBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("🕵️ Mafia").font(.system(size: 48, weight: .bold)).foregroundColor(.white)
+                    Text(vm.state.phase == "day" ? "☀️ Day \(vm.state.round) — Vote to eliminate"
+                         : "🌙 Night — Mafia is choosing")
+                        .font(.title3).foregroundColor(.white.opacity(0.5))
+                }
+                Spacer()
+                TimerRing(secondsLeft: vm.state.secondsLeft, total: vm.state.phase == "day" ? 60 : 30)
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            // Players grid
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: 20) {
+                ForEach(vm.state.players) { p in
+                    MafiaPlayerTile(player: p)
+                }
+            }
+            .padding(.horizontal, 60)
+
+            // Vote tally (day only)
+            if vm.state.phase == "day" && !vm.state.votes.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Vote Tally").font(.headline).foregroundColor(.white.opacity(0.5))
+                    ForEach(vm.state.votes.sorted(by: { $0.value > $1.value }), id: \.key) { name, count in
+                        HStack {
+                            Text(name).foregroundColor(.white)
+                            Spacer()
+                            HStack(spacing: 4) {
+                                ForEach(0..<count, id: \.self) { _ in
+                                    Circle().fill(Color.red).frame(width: 12, height: 12)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(20)
+                .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.05)))
+                .padding(.horizontal, 60)
+            }
+
+            if let eliminated = vm.state.lastEliminated {
+                Text("\(eliminated) was eliminated!")
+                    .font(.title3.bold()).foregroundColor(.red)
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: vm.state.phase == "day" ? "0a0814" : "00000a").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct MafiaPlayer: Identifiable {
+    let id: String
+    let name: String
+    var isAlive: Bool
+    var revealedRole: String?
+}
+
+private struct MafiaPlayerTile: View {
+    let player: MafiaPlayer
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(player.isAlive ? Color.white.opacity(0.1) : Color.red.opacity(0.15))
+                    .frame(width: 64, height: 64)
+                Text(player.isAlive ? String(player.name.prefix(1)) : "💀")
+                    .font(.title.bold()).foregroundColor(.white)
+            }
+            Text(player.name).font(.subheadline)
+                .foregroundColor(player.isAlive ? .white : .white.opacity(0.3))
+                .strikethrough(!player.isAlive)
+            if let role = player.revealedRole {
+                Text(role).font(.caption2.bold()).foregroundColor(.red)
+            }
+        }
+        .opacity(player.isAlive ? 1 : 0.5)
+    }
+}
+
+struct MafiaBoardState {
+    var players: [MafiaPlayer] = []
+    var phase = "day"
+    var round = 1
+    var secondsLeft = 60
+    var votes: [String: Int] = [:]
+    var lastEliminated: String? = nil
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["phase"]?.value as? String        { phase = v }
+        if let v = data["round"]?.value as? Int           { round = v }
+        if let v = data["secondsLeft"]?.value as? Int     { secondsLeft = v }
+        if let v = data["lastEliminated"]?.value as? String { lastEliminated = v }
+        if let v = data["votes"]?.value as? [String: Int] { votes = v }
+        if let ps = data["players"]?.value as? [[String: Any]] {
+            players = ps.compactMap { d -> MafiaPlayer? in
+                guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+                return MafiaPlayer(id: id, name: name,
+                                   isAlive: d["isAlive"] as? Bool ?? true,
+                                   revealedRole: d["revealedRole"] as? String)
+            }
+        }
+    }
+}
+
+@MainActor final class MafiaBoardViewModel: ObservableObject {
+    @Published var state = MafiaBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Roulette Board
+
+struct TVRouletteBoardView: View {
+    let room: Room
+    @StateObject private var vm = RouletteBoardViewModel()
+
+    // Numbers 0-36 arranged in the European layout
+    private let numberGrid: [[Int]] = [
+        [3,6,9,12,15,18,21,24,27,30,33,36],
+        [2,5,8,11,14,17,20,23,26,29,32,35],
+        [1,4,7,10,13,16,19,22,25,28,31,34],
+    ]
+
+    var body: some View {
+        HStack(spacing: 60) {
+            // Left — wheel indicator + result
+            VStack(spacing: 24) {
+                Text("🎡 Roulette").font(.system(size: 40, weight: .bold)).foregroundColor(.white)
+
+                ZStack {
+                    Circle().stroke(Color.white.opacity(0.15), lineWidth: 4).frame(width: 280, height: 280)
+                    Circle().stroke(Color.green.opacity(0.5), lineWidth: 2).frame(width: 220, height: 220)
+
+                    if vm.state.isSpinning {
+                        Text("🎰").font(.system(size: 80))
+                    } else if let result = vm.state.lastResult {
+                        VStack(spacing: 4) {
+                            Text("\(result)").font(.system(size: 72, weight: .black))
+                                .foregroundColor(isRed(result) ? .red : result == 0 ? .green : .white)
+                            Text(isRed(result) ? "RED" : result == 0 ? "GREEN" : "BLACK")
+                                .font(.headline).foregroundColor(.white.opacity(0.5))
+                        }
+                    } else {
+                        Text("Place\nyour bets").font(.title3).foregroundColor(.white.opacity(0.4))
+                            .multilineTextAlignment(.center)
+                    }
+                }
+
+                // Total bets per player
+                VStack(spacing: 8) {
+                    ForEach(room.players) { p in
+                        HStack {
+                            Text(p.name).foregroundColor(.white)
+                            Spacer()
+                            Text("Bet: $\(vm.state.playerBets[p.id] ?? 0)").foregroundColor(.cyan)
+                        }
+                        .padding(.horizontal, 20)
+                    }
+                }
+            }
+            .frame(maxWidth: 400)
+
+            // Right — number grid
+            VStack(spacing: 4) {
+                Text("0").font(.headline.bold()).foregroundColor(.white)
+                    .frame(maxWidth: .infinity).padding(.vertical, 10)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.green.opacity(0.5)))
+                    .padding(.horizontal, 4)
+
+                ForEach(Array(numberGrid.enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 4) {
+                        ForEach(row, id: \.self) { num in
+                            Text("\(num)").font(.caption.bold())
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity).padding(.vertical, 8)
+                                .background(RoundedRectangle(cornerRadius: 4)
+                                    .fill(isRed(num) ? Color.red.opacity(0.7) : Color.black.opacity(0.7)))
+                                .overlay(
+                                    vm.state.lastResult == num ?
+                                    RoundedRectangle(cornerRadius: 4).strokeBorder(.yellow, lineWidth: 3) : nil
+                                )
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: 500)
+        }
+        .padding(60)
+        .background(Color(hex: "060d00").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+
+    private func isRed(_ n: Int) -> Bool {
+        [1,3,5,7,9,12,14,16,18,19,21,23,25,27,30,32,34,36].contains(n)
+    }
+}
+
+struct RouletteBoardState {
+    var isSpinning = false
+    var lastResult: Int? = nil
+    var playerBets: [String: Int] = [:]
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["isSpinning"]?.value as? Bool  { isSpinning = v }
+        if let v = data["lastResult"]?.value as? Int   { lastResult = v }
+        if let v = data["playerBets"]?.value as? [String: Int] { playerBets = v }
+    }
+}
+
+@MainActor final class RouletteBoardViewModel: ObservableObject {
+    @Published var state = RouletteBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Digit Guess Board (Mastermind / shared guess history)
+
+struct TVDigitGuessBoardView: View {
+    let room: Room
+    @StateObject private var vm = DigitGuessBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("🔢 Digit Guess").font(.system(size: 48, weight: .bold)).foregroundColor(.white)
+                .padding(.top, 40)
+
+            Text(vm.state.solved ? "Code cracked! 🎉" : "Guess the secret 4-digit code")
+                .font(.title3).foregroundColor(vm.state.solved ? .green : .white.opacity(0.5))
+
+            // Player columns
+            HStack(alignment: .top, spacing: 24) {
+                ForEach(vm.state.playerColumns) { col in
+                    VStack(spacing: 8) {
+                        Text(col.playerName).font(.headline).foregroundColor(.white)
+                            .padding(.bottom, 4)
+                        ForEach(Array(col.guesses.enumerated()), id: \.offset) { _, guess in
+                            HStack {
+                                Text(guess.code)
+                                    .font(.system(.body, design: .monospaced).bold())
+                                    .foregroundColor(.white)
+                                Spacer()
+                                Text("🐂\(guess.bulls) 🐄\(guess.cows)")
+                                    .font(.caption).foregroundColor(.white.opacity(0.6))
+                            }
+                            .padding(.horizontal, 12).padding(.vertical, 6)
+                            .background(RoundedRectangle(cornerRadius: 8)
+                                .fill(guess.bulls == 4 ? Color.green.opacity(0.3) : Color.white.opacity(0.05)))
+                        }
+                        Spacer()
+                    }
+                    .padding(16)
+                    .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.05)))
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(.horizontal, 60)
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct DigitGuessEntry: Identifiable {
+    let id = UUID()
+    let code: String
+    let bulls: Int
+    let cows: Int
+}
+
+struct DigitGuessPlayerColumn: Identifiable {
+    let id: String
+    let playerName: String
+    var guesses: [DigitGuessEntry]
+}
+
+struct DigitGuessBoardState {
+    var playerColumns: [DigitGuessPlayerColumn] = []
+    var solved = false
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["solved"]?.value as? Bool { solved = v }
+        if let cols = data["players"]?.value as? [[String: Any]] {
+            playerColumns = cols.compactMap { d -> DigitGuessPlayerColumn? in
+                guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+                let guesses = (d["guesses"] as? [[String: Any]] ?? []).compactMap { g -> DigitGuessEntry? in
+                    guard let code = g["code"] as? String else { return nil }
+                    return DigitGuessEntry(code: code,
+                                          bulls: g["bulls"] as? Int ?? 0,
+                                          cows: g["cows"] as? Int ?? 0)
+                }
+                return DigitGuessPlayerColumn(id: id, playerName: name, guesses: guesses)
+            }
+        }
+    }
+}
+
+@MainActor final class DigitGuessBoardViewModel: ObservableObject {
+    @Published var state = DigitGuessBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Raja Mantri Board
+
+struct TVRajaMantriBoard: View {
+    let room: Room
+    @StateObject private var vm = RajaMantriViewModel()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            HStack {
+                Text("👑 Raja Mantri").font(.system(size: 44, weight: .bold)).foregroundColor(.white)
+                Spacer()
+                Text("Round \(vm.state.round)").font(.title3).foregroundColor(.white.opacity(0.4))
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            Text(vm.state.phaseLabel).font(.title2).foregroundColor(.cyan.opacity(0.8))
+
+            // Player role cards (revealed after round ends)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: min(room.players.count, 4)),
+                      spacing: 20) {
+                ForEach(vm.state.playerRoles) { p in
+                    RajaMantriPlayerCard(player: p)
+                }
+            }
+            .padding(.horizontal, 60)
+
+            if let result = vm.state.roundResult {
+                Text(result).font(.title3.bold()).foregroundColor(.yellow)
+            }
+
+            // Score table
+            VStack(spacing: 10) {
+                ForEach(room.players.sorted(by: { $0.score > $1.score })) { p in
+                    HStack {
+                        Text(p.name).foregroundColor(.white)
+                        Spacer()
+                        Text("\(p.score) pts").font(.headline.bold()).foregroundColor(.cyan)
+                    }
+                    .padding(.horizontal, 24)
+                }
+            }
+            .padding(.vertical, 16)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.04)))
+            .padding(.horizontal, 60)
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0814").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct RajaPlayer: Identifiable {
+    let id: String
+    let name: String
+    var revealedRole: String?
+    var isAccused: Bool
+}
+
+private struct RajaMantriPlayerCard: View {
+    let player: RajaPlayer
+    var body: some View {
+        VStack(spacing: 10) {
+            Text(player.revealedRole.map { roleEmoji($0) } ?? "🂠").font(.system(size: 48))
+            Text(player.name).font(.headline).foregroundColor(.white)
+            if let role = player.revealedRole {
+                Text(role).font(.caption.bold()).foregroundColor(roleColor(role))
+            }
+            if player.isAccused {
+                Text("← ACCUSED").font(.caption2.bold()).foregroundColor(.red)
+            }
+        }
+        .padding(20)
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.06)))
+    }
+
+    private func roleEmoji(_ r: String) -> String {
+        switch r { case "Raja": return "👑"; case "Mantri": return "🎩"; case "Chor": return "🦹"; default: return "⚔️" }
+    }
+    private func roleColor(_ r: String) -> Color {
+        switch r { case "Raja": return .yellow; case "Mantri": return .purple; case "Chor": return .red; default: return .cyan }
+    }
+}
+
+struct RajaMantriState {
+    var round = 1
+    var phase = "deal"
+    var playerRoles: [RajaPlayer] = []
+    var roundResult: String? = nil
+
+    var phaseLabel: String {
+        switch phase {
+        case "deal":    return "Roles are being dealt…"
+        case "guess":   return "Sipahi is guessing the Chor!"
+        case "reveal":  return "Roles revealed!"
+        default:        return phase
+        }
+    }
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["round"]?.value as? Int           { round = v }
+        if let v = data["phase"]?.value as? String        { phase = v }
+        if let v = data["roundResult"]?.value as? String  { roundResult = v }
+        if let ps = data["players"]?.value as? [[String: Any]] {
+            playerRoles = ps.compactMap { d -> RajaPlayer? in
+                guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+                return RajaPlayer(id: id, name: name,
+                                  revealedRole: d["role"] as? String,
+                                  isAccused: d["isAccused"] as? Bool ?? false)
+            }
+        }
+    }
+}
+
+@MainActor final class RajaMantriViewModel: ObservableObject {
+    @Published var state = RajaMantriState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Tambola Board
+
+struct TVTambolaBoardView: View {
+    let room: Room
+    @StateObject private var vm = TambolaBoardViewModel()
+
+    var body: some View {
+        HStack(spacing: 60) {
+            // Left — caller column
+            VStack(spacing: 20) {
+                Text("🎱 Tambola").font(.system(size: 40, weight: .bold)).foregroundColor(.white)
+
+                if let last = vm.state.lastCalled {
+                    VStack(spacing: 8) {
+                        Text("\(last)").font(.system(size: 96, weight: .black))
+                            .foregroundColor(.yellow)
+                        Text("Last Called").font(.subheadline).foregroundColor(.white.opacity(0.4))
+                    }
+                    .padding(24)
+                    .background(RoundedRectangle(cornerRadius: 20).fill(Color.yellow.opacity(0.1)))
+                }
+
+                Text("Called: \(vm.state.calledNumbers.count)").font(.body).foregroundColor(.white.opacity(0.5))
+
+                Spacer()
+
+                // Claims
+                ForEach(vm.state.claims, id: \.self) { claim in
+                    Text("🎉 \(claim)").font(.headline).foregroundColor(.green)
+                }
+            }
+            .frame(width: 320)
+
+            // Right — number board (1–90 grid)
+            LazyVGrid(columns: Array(repeating: GridItem(.fixed(56)), count: 10), spacing: 8) {
+                ForEach(1...90, id: \.self) { num in
+                    Text("\(num)")
+                        .font(.system(.body, design: .monospaced).bold())
+                        .foregroundColor(vm.state.calledNumbers.contains(num) ? .black : .white)
+                        .frame(width: 50, height: 40)
+                        .background(RoundedRectangle(cornerRadius: 6)
+                            .fill(vm.state.calledNumbers.contains(num)
+                                  ? Color.yellow : Color.white.opacity(0.06)))
+                }
+            }
+            .padding(24)
+        }
+        .padding(60)
+        .background(Color(hex: "0a0814").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct TambolaBoardState {
+    var calledNumbers: Set<Int> = []
+    var lastCalled: Int? = nil
+    var claims: [String] = []
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["called"]?.value as? [Int]       { calledNumbers = Set(v) }
+        if let v = data["lastCalled"]?.value as? Int      { lastCalled = v }
+        if let v = data["claims"]?.value as? [String]     { claims = v }
+    }
+}
+
+@MainActor final class TambolaBoardViewModel: ObservableObject {
+    @Published var state = TambolaBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Stock Panic Board
+
+struct TVStockPanicBoardView: View {
+    let room: Room
+    @StateObject private var vm = StockPanicBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            HStack {
+                Text("📈 Stock Panic").font(.system(size: 44, weight: .bold)).foregroundColor(.white)
+                Spacer()
+                if let news = vm.state.latestNews {
+                    HStack(spacing: 8) {
+                        Image(systemName: "newspaper.fill").foregroundColor(.yellow)
+                        Text(news).font(.subheadline).foregroundColor(.yellow)
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 8)
+                    .background(Capsule().fill(Color.yellow.opacity(0.15)))
+                }
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            // Stock ticker
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 16) {
+                ForEach(vm.state.stocks) { stock in
+                    StockTile(stock: stock)
+                }
+            }
+            .padding(.horizontal, 60)
+
+            // Leaderboard
+            HStack(alignment: .top, spacing: 0) {
+                ForEach(room.players.sorted(by: { $0.score > $1.score })) { p in
+                    VStack(spacing: 4) {
+                        Text(p.name).font(.subheadline).foregroundColor(.white)
+                        Text("$\(p.score)").font(.headline.bold()).foregroundColor(.green)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(20)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Color.white.opacity(0.04)))
+            .padding(.horizontal, 60)
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct StockEntry: Identifiable {
+    let id: String
+    let name: String
+    var price: Int
+    var change: Int
+}
+
+private struct StockTile: View {
+    let stock: StockEntry
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(stock.name).font(.headline).foregroundColor(.white)
+            Text("$\(stock.price)").font(.system(size: 32, weight: .bold))
+                .foregroundColor(stock.change >= 0 ? .green : .red)
+            HStack(spacing: 4) {
+                Image(systemName: stock.change >= 0 ? "arrow.up" : "arrow.down")
+                Text("\(abs(stock.change))").font(.caption)
+            }
+            .foregroundColor(stock.change >= 0 ? .green : .red)
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Color.white.opacity(0.06)))
+    }
+}
+
+struct StockPanicBoardState {
+    var stocks: [StockEntry] = []
+    var latestNews: String? = nil
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["latestNews"]?.value as? String { latestNews = v }
+        if let s = data["stocks"]?.value as? [[String: Any]] {
+            stocks = s.compactMap { d -> StockEntry? in
+                guard let id = d["id"] as? String, let name = d["name"] as? String else { return nil }
+                return StockEntry(id: id, name: name,
+                                  price: d["price"] as? Int ?? 0,
+                                  change: d["change"] as? Int ?? 0)
+            }
+        }
+    }
+}
+
+@MainActor final class StockPanicBoardViewModel: ObservableObject {
+    @Published var state = StockPanicBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Mind Meld Board
+
+struct TVMindMeldBoardView: View {
+    let room: Room
+    @StateObject private var vm = MindMeldBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Text("🔮 Mind Meld").font(.system(size: 48, weight: .bold)).foregroundColor(.white)
+                .padding(.top, 40)
+
+            if let category = vm.state.category {
+                Text("Category: \(category)").font(.title2).foregroundColor(.cyan)
+            }
+
+            if vm.state.showReveal {
+                // Reveal all words
+                VStack(spacing: 16) {
+                    Text("Words submitted:").font(.headline).foregroundColor(.white.opacity(0.5))
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 12) {
+                        ForEach(vm.state.submissions) { sub in
+                            VStack(spacing: 4) {
+                                Text(sub.word).font(.title2.bold()).foregroundColor(.white)
+                                Text(sub.playerName).font(.caption).foregroundColor(.white.opacity(0.5))
+                                if sub.isMeld {
+                                    Text("MELD +\(sub.meldCount)!").font(.caption.bold()).foregroundColor(.green)
+                                }
+                            }
+                            .padding(12)
+                            .background(RoundedRectangle(cornerRadius: 12)
+                                .fill(sub.isMeld ? Color.green.opacity(0.2) : Color.white.opacity(0.06)))
+                        }
+                    }
+                }
+                .padding(.horizontal, 60)
+            } else {
+                // Waiting for submissions
+                VStack(spacing: 16) {
+                    let submitted = vm.state.submissions.count
+                    let total = room.players.count
+                    Text("\(submitted) / \(total) submitted").font(.title2).foregroundColor(.white.opacity(0.6))
+                    HStack(spacing: 12) {
+                        ForEach(room.players) { p in
+                            VStack(spacing: 6) {
+                                Image(systemName: vm.state.submittedIDs.contains(p.id)
+                                      ? "checkmark.circle.fill" : "circle")
+                                    .font(.title).foregroundColor(vm.state.submittedIDs.contains(p.id) ? .green : .white.opacity(0.3))
+                                Text(p.name).font(.caption).foregroundColor(.white.opacity(0.6))
+                            }
+                        }
+                    }
+                }
+            }
+
+            TVScoreHeader(players: room.players, currentPlayerID: nil)
+
+            Spacer()
+        }
+        .background(Color(hex: "0d0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct MeldSubmission: Identifiable {
+    let id: String
+    let playerName: String
+    let word: String
+    var isMeld: Bool
+    var meldCount: Int
+}
+
+struct MindMeldBoardState {
+    var category: String? = nil
+    var submittedIDs: Set<String> = []
+    var submissions: [MeldSubmission] = []
+    var showReveal = false
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["category"]?.value as? String        { category = v }
+        if let v = data["showReveal"]?.value as? Bool        { showReveal = v }
+        if let v = data["submittedIDs"]?.value as? [String]  { submittedIDs = Set(v) }
+        if let subs = data["submissions"]?.value as? [[String: Any]] {
+            submissions = subs.compactMap { d -> MeldSubmission? in
+                guard let id = d["id"] as? String,
+                      let name = d["playerName"] as? String,
+                      let word = d["word"] as? String else { return nil }
+                return MeldSubmission(id: id, playerName: name, word: word,
+                                      isMeld: d["isMeld"] as? Bool ?? false,
+                                      meldCount: d["meldCount"] as? Int ?? 0)
+            }
+        }
+    }
+}
+
+@MainActor final class MindMeldBoardViewModel: ObservableObject {
+    @Published var state = MindMeldBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Hot Grid Board
+
+struct TVHotGridBoardView: View {
+    let room: Room
+    @StateObject private var vm = HotGridBoardViewModel()
+
+    private let gridSize = 5
+
+    var body: some View {
+        VStack(spacing: 32) {
+            HStack {
+                Text("💣 Hot Grid").font(.system(size: 44, weight: .bold)).foregroundColor(.white)
+                Spacer()
+                Text("\(vm.state.currentPlayerName)'s turn").font(.title3).foregroundColor(.yellow)
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            TVScoreHeader(players: room.players, currentPlayerID: vm.state.currentPlayerID)
+
+            // 5×5 grid
+            VStack(spacing: 12) {
+                ForEach(0..<gridSize, id: \.self) { row in
+                    HStack(spacing: 12) {
+                        ForEach(0..<gridSize, id: \.self) { col in
+                            let idx = row * gridSize + col
+                            let tile = vm.state.tiles[safe: idx]
+                            HotGridTileView(tile: tile)
+                        }
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a0a").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+enum HotGridTileContent { case hidden, coin(Int), trap, teleport }
+
+private struct HotGridTileView: View {
+    let tile: HotGridTileContent?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(tileFill)
+                .frame(width: 100, height: 100)
+            tileContent
+        }
+    }
+
+    @ViewBuilder private var tileContent: some View {
+        switch tile {
+        case .hidden, .none:
+            Text("?").font(.system(size: 36, weight: .bold)).foregroundColor(.white.opacity(0.3))
+        case .coin(let v):
+            VStack(spacing: 2) {
+                Text("🪙").font(.system(size: 36))
+                Text("+\(v)").font(.caption.bold()).foregroundColor(.yellow)
+            }
+        case .trap:
+            Text("💀").font(.system(size: 40))
+        case .teleport:
+            Text("🌀").font(.system(size: 40))
+        }
+    }
+
+    private var tileFill: Color {
+        switch tile {
+        case .hidden, .none: return Color(hex: "1a1a1a")
+        case .coin:          return Color.yellow.opacity(0.2)
+        case .trap:          return Color.red.opacity(0.25)
+        case .teleport:      return Color.purple.opacity(0.25)
+        }
+    }
+}
+
+struct HotGridBoardState {
+    var tiles: [HotGridTileContent] = Array(repeating: .hidden, count: 25)
+    var currentPlayerID = ""
+    var currentPlayerName = ""
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["currentPlayerID"]?.value as? String   { currentPlayerID = v }
+        if let v = data["currentPlayerName"]?.value as? String { currentPlayerName = v }
+        if let rawTiles = data["tiles"]?.value as? [String] {
+            tiles = rawTiles.map { t -> HotGridTileContent in
+                if t == "hidden"    { return .hidden }
+                if t == "trap"      { return .trap }
+                if t == "teleport"  { return .teleport }
+                if let v = Int(t)   { return .coin(v) }
+                return .hidden
+            }
+        }
+    }
+}
+
+@MainActor final class HotGridBoardViewModel: ObservableObject {
+    @Published var state = HotGridBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Speed Sculptor Board
+
+struct TVSpeedSculptorBoardView: View {
+    let room: Room
+    @StateObject private var vm = SpeedSculptorBoardViewModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            HStack {
+                Text("🎨 Speed Sculptor").font(.system(size: 40, weight: .bold)).foregroundColor(.white)
+                Spacer()
+                if let prompt = vm.state.prompt {
+                    Text("Drawing: \(prompt)").font(.title2.bold()).foregroundColor(.yellow)
+                }
+            }
+            .padding(.horizontal, 60).padding(.top, 40)
+
+            if vm.state.votingPhase {
+                // Show all drawings + vote tally
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: min(room.players.count, 3)),
+                          spacing: 20) {
+                    ForEach(vm.state.drawings) { drawing in
+                        DrawingCard(drawing: drawing)
+                    }
+                }
+                .padding(.horizontal, 60)
+            } else {
+                // Countdown while players draw
+                VStack(spacing: 24) {
+                    TimerRing(secondsLeft: vm.state.secondsLeft, total: 20)
+                        .frame(width: 120, height: 120)
+                    Text("Players are drawing…").font(.title2).foregroundColor(.white.opacity(0.5))
+                    let submitted = vm.state.submittedCount
+                    Text("\(submitted) / \(room.players.count) submitted")
+                        .font(.subheadline).foregroundColor(.white.opacity(0.4))
+                }
+            }
+
+            Spacer()
+        }
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+struct PlayerDrawing: Identifiable {
+    let id: String
+    let playerName: String
+    let lines: [[[Double]]]  // simplified line arrays from server
+    var voteCount: Int
+}
+
+private struct DrawingCard: View {
+    let drawing: PlayerDrawing
+    var body: some View {
+        VStack(spacing: 8) {
+            Canvas { ctx, size in
+                for line in drawing.lines {
+                    var path = Path()
+                    let pts = line.compactMap { p -> CGPoint? in
+                        guard p.count >= 2 else { return nil }
+                        return CGPoint(x: p[0] * size.width, y: p[1] * size.height)
+                    }
+                    guard let first = pts.first else { continue }
+                    path.move(to: first)
+                    for pt in pts.dropFirst() { path.addLine(to: pt) }
+                    ctx.stroke(path, with: .color(.black), lineWidth: 3)
+                }
+            }
+            .background(Color.white)
+            .frame(height: 220)
+            .cornerRadius(12)
+
+            HStack {
+                Text(drawing.playerName).font(.headline).foregroundColor(.white)
+                Spacer()
+                HStack(spacing: 4) {
+                    Image(systemName: "hand.thumbsup.fill").foregroundColor(.cyan)
+                    Text("\(drawing.voteCount)").font(.headline.bold()).foregroundColor(.cyan)
+                }
+            }
+        }
+    }
+}
+
+struct SpeedSculptorBoardState {
+    var prompt: String? = nil
+    var secondsLeft = 20
+    var votingPhase = false
+    var submittedCount = 0
+    var drawings: [PlayerDrawing] = []
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let v = data["prompt"]?.value as? String       { prompt = v }
+        if let v = data["secondsLeft"]?.value as? Int     { secondsLeft = v }
+        if let v = data["votingPhase"]?.value as? Bool    { votingPhase = v }
+        if let v = data["submittedCount"]?.value as? Int  { submittedCount = v }
+        if let ds = data["drawings"]?.value as? [[String: Any]] {
+            drawings = ds.compactMap { d -> PlayerDrawing? in
+                guard let id = d["id"] as? String, let name = d["playerName"] as? String else { return nil }
+                return PlayerDrawing(id: id, playerName: name,
+                                     lines: d["lines"] as? [[[Double]]] ?? [],
+                                     voteCount: d["voteCount"] as? Int ?? 0)
+            }
+        }
+    }
+}
+
+@MainActor final class SpeedSculptorBoardViewModel: ObservableObject {
+    @Published var state = SpeedSculptorBoardState()
+    private let socket = GameSocketManager.shared
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.state.update(from: r.boardState)
+        }
+    }
+}
+
+// MARK: - Array safe subscript
+
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard index >= 0, index < count else { return nil }
+        return self[index]
+    }
+}
+
+// MARK: - TimerRing (shared across board views)
+
+struct TimerRing: View {
+    let secondsLeft: Int
+    let total: Int
+
+    private var progress: Double { total > 0 ? Double(secondsLeft) / Double(total) : 0 }
+
+    var body: some View {
+        ZStack {
+            Circle().stroke(Color.white.opacity(0.1), lineWidth: 6)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(progress > 0.4 ? Color.cyan : Color.red,
+                        style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 1), value: secondsLeft)
+            Text("\(secondsLeft)")
+                .font(.system(size: 22, weight: .bold, design: .monospaced))
+                .foregroundColor(.white)
+        }
+        .frame(width: 70, height: 70)
+    }
+}

--- a/ios/GameLabTV/Views/Games/TVHeistBoardView.swift
+++ b/ios/GameLabTV/Views/Games/TVHeistBoardView.swift
@@ -232,30 +232,7 @@ private struct PhaseTag: View {
     }
 }
 
-private struct TimerRing: View {
-    let secondsLeft: Int
-    let total: Int
-
-    private var progress: Double { Double(secondsLeft) / Double(total) }
-
-    var body: some View {
-        ZStack {
-            Circle().stroke(Color.white.opacity(0.1), lineWidth: 6)
-            Circle()
-                .trim(from: 0, to: progress)
-                .stroke(
-                    progress > 0.4 ? Color.cyan : Color.red,
-                    style: StrokeStyle(lineWidth: 6, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-                .animation(.linear(duration: 1), value: secondsLeft)
-            Text("\(secondsLeft)")
-                .font(.system(size: 22, weight: .bold, design: .monospaced))
-                .foregroundColor(.white)
-        }
-        .frame(width: 70, height: 70)
-    }
-}
+// TimerRing defined in TVClassicGameBoards.swift
 
 private struct HeistPlayerRow: View {
     let status: HeistPlayerStatus
@@ -397,8 +374,52 @@ struct HeistBoardState {
         if let r = data["round"]?.value as? Int       { round = r }
         if let s = data["secondsLeft"]?.value as? Int { secondsLeft = s }
         if let p = data["phase"]?.value as? String    { phase = HeistPhase(rawValue: p) ?? .guardSets }
-        // Camera arcs, thief positions, and player statuses decoded similarly
-        // (full server payload parsing omitted for brevity — server sends these fields)
+
+        // Camera positions the Guard activated this round
+        if let cams = data["cameraPositions"]?.value as? [[String: Any]] {
+            cameraPositions = cams.compactMap { dict -> GridPos? in
+                guard let c = dict["col"] as? Int, let r = dict["row"] as? Int else { return nil }
+                return GridPos(col: c, row: r)
+            }
+        }
+
+        // Tiles covered by camera arcs (computed server-side)
+        if let arcs = data["cameraArcTiles"]?.value as? [[String: Any]] {
+            cameraArcTiles = Set(arcs.compactMap { dict -> GridPos? in
+                guard let c = dict["col"] as? Int, let r = dict["row"] as? Int else { return nil }
+                return GridPos(col: c, row: r)
+            })
+        }
+
+        // Each thief's position (playerID → {col, row})
+        if let positions = data["thiefPositions"]?.value as? [String: [String: Any]] {
+            thiefPositions = positions.compactMapValues { dict -> GridPos? in
+                guard let c = dict["col"] as? Int, let r = dict["row"] as? Int else { return nil }
+                return GridPos(col: c, row: r)
+            }
+        }
+
+        // Player status array
+        if let statuses = data["playerStatuses"]?.value as? [[String: Any]] {
+            let palette: [Color] = [.cyan, .yellow, .green, .orange, .purple, .pink]
+            playerStatuses = statuses.enumerated().compactMap { idx, dict -> HeistPlayerStatus? in
+                guard let id   = dict["id"]   as? String,
+                      let name = dict["name"] as? String,
+                      let rs   = dict["role"] as? String else { return nil }
+                return HeistPlayerStatus(
+                    id: id, name: name,
+                    role: rs == "guard" ? .guard : .thief,
+                    color: palette[idx % palette.count],
+                    isCaught: dict["isCaught"] as? Bool ?? false,
+                    hasEscaped: dict["hasEscaped"] as? Bool ?? false
+                )
+            }
+        }
+
+        // Game over
+        if let w = data["winner"]?.value as? String {
+            winner = w == "guard" ? .guard_ : .thieves
+        }
     }
 }
 

--- a/ios/GameLabTV/Views/Games/TVHeistBoardView.swift
+++ b/ios/GameLabTV/Views/Games/TVHeistBoardView.swift
@@ -1,0 +1,462 @@
+import SwiftUI
+
+// MARK: - Heist — TV Board
+//
+// GAME RULES:
+//   • 3–6 players. One is secretly the Guard, rest are Thieves.
+//   • TV shows the full vault floor plan (5×7 grid).
+//   • Guard's phone shows camera positions + coverage arcs (private).
+//   • Thieves' phones show only their own position (private).
+//   • Each round: Guard sets cameras (phone), Thieves move 1 tile (phone).
+//   • If a Thief lands on a camera-covered tile → caught, eliminated.
+//   • Thieves must reach the Vault tile (center) and escape to EXIT tile.
+//   • Guard wins if all Thieves caught. Thieves win if any escapes.
+
+struct TVHeistBoardView: View {
+    let room: Room
+    @StateObject private var vm = HeistBoardViewModel()
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Main board — 5/7 width
+            ZStack {
+                Color(hex: "0a0a14").ignoresSafeArea()
+
+                VStack(spacing: 24) {
+                    headerBar
+                    boardGrid
+                }
+                .padding(48)
+            }
+            .frame(maxWidth: .infinity)
+
+            // Right sidebar — player status
+            playerSidebar
+                .frame(width: 320)
+                .background(Color.white.opacity(0.04))
+        }
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+
+    // MARK: - Header
+
+    private var headerBar: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("🏦 Heist")
+                    .font(.system(size: 36, weight: .bold))
+                    .foregroundColor(.white)
+                Text("Round \(vm.state.round) of \(HeistConstants.maxRounds)")
+                    .font(.body)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+
+            Spacer()
+
+            // Phase indicator
+            PhaseTag(phase: vm.state.phase)
+
+            Spacer()
+
+            // Countdown timer ring
+            TimerRing(
+                secondsLeft: vm.state.secondsLeft,
+                total: HeistConstants.secondsPerPhase
+            )
+        }
+    }
+
+    // MARK: - Board Grid
+
+    private var boardGrid: some View {
+        let cols = HeistConstants.cols
+        let rows = HeistConstants.rows
+
+        return VStack(spacing: 4) {
+            ForEach(0..<rows, id: \.self) { row in
+                HStack(spacing: 4) {
+                    ForEach(0..<cols, id: \.self) { col in
+                        let pos = GridPos(col: col, row: row)
+                        HeistTile(
+                            pos: pos,
+                            tileType: vm.state.tileType(at: pos),
+                            cameraArc: vm.state.cameraArcCovers(pos),
+                            thieves: vm.state.thieves(at: pos),
+                            isGuardKnown: vm.state.isGuardRevealedAt(pos)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sidebar
+
+    private var playerSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Players")
+                .font(.headline)
+                .foregroundColor(.white.opacity(0.5))
+                .padding(24)
+
+            Divider().background(Color.white.opacity(0.1))
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(vm.state.playerStatuses) { status in
+                        HeistPlayerRow(status: status)
+                        Divider().background(Color.white.opacity(0.06))
+                    }
+                }
+            }
+
+            Spacer()
+
+            if let winner = vm.state.winner {
+                WinnerBanner(winner: winner)
+                    .padding(24)
+            }
+        }
+    }
+}
+
+// MARK: - Tile View
+
+private struct HeistTile: View {
+    let pos: GridPos
+    let tileType: HeistTileType
+    let cameraArc: Bool        // true → camera watches this tile this round
+    let thieves: [HeistThiefStatus]
+    let isGuardKnown: Bool
+
+    var body: some View {
+        ZStack {
+            // Base tile
+            RoundedRectangle(cornerRadius: 6)
+                .fill(baseFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(borderColor, lineWidth: 1)
+                )
+
+            // Camera coverage overlay
+            if cameraArc {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.red.opacity(0.25))
+                    .overlay(
+                        Image(systemName: "video.fill")
+                            .font(.caption2)
+                            .foregroundColor(.red.opacity(0.7))
+                            .padding(2),
+                        alignment: .topTrailing
+                    )
+            }
+
+            // Tile icon
+            tileIcon
+
+            // Thieves (shown as coloured dots)
+            if !thieves.isEmpty {
+                HStack(spacing: 3) {
+                    ForEach(thieves) { t in
+                        Circle()
+                            .fill(t.color)
+                            .frame(width: 14, height: 14)
+                            .shadow(color: t.color, radius: 4)
+                    }
+                }
+                .padding(.bottom, 4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            }
+        }
+        .frame(width: tileSize, height: tileSize)
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: thieves.map(\.id))
+    }
+
+    private var tileSize: CGFloat { 88 }
+
+    private var baseFill: Color {
+        switch tileType {
+        case .empty:   return Color(hex: "1a1a2e")
+        case .wall:    return Color(hex: "0d0d14")
+        case .vault:   return Color(hex: "2d1b00")
+        case .exit:    return Color(hex: "0d2d00")
+        case .camera:  return Color(hex: "2d0000")
+        }
+    }
+
+    private var borderColor: Color {
+        switch tileType {
+        case .vault:  return .yellow.opacity(0.6)
+        case .exit:   return .green.opacity(0.6)
+        case .camera: return .red.opacity(0.4)
+        default:      return Color.white.opacity(0.06)
+        }
+    }
+
+    @ViewBuilder
+    private var tileIcon: some View {
+        switch tileType {
+        case .vault:
+            Text("💰").font(.system(size: 28))
+        case .exit:
+            Text("🚪").font(.system(size: 28))
+        case .camera:
+            Text("📷").font(.system(size: 22)).opacity(isGuardKnown ? 1 : 0)
+        case .wall:
+            Rectangle()
+                .fill(Color(hex: "080810"))
+                .cornerRadius(4)
+                .padding(4)
+        default:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Supporting views
+
+private struct PhaseTag: View {
+    let phase: HeistPhase
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle().fill(phase.color).frame(width: 10, height: 10)
+            Text(phase.label)
+                .font(.headline)
+                .foregroundColor(phase.color)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(Capsule().fill(phase.color.opacity(0.15)))
+    }
+}
+
+private struct TimerRing: View {
+    let secondsLeft: Int
+    let total: Int
+
+    private var progress: Double { Double(secondsLeft) / Double(total) }
+
+    var body: some View {
+        ZStack {
+            Circle().stroke(Color.white.opacity(0.1), lineWidth: 6)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    progress > 0.4 ? Color.cyan : Color.red,
+                    style: StrokeStyle(lineWidth: 6, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 1), value: secondsLeft)
+            Text("\(secondsLeft)")
+                .font(.system(size: 22, weight: .bold, design: .monospaced))
+                .foregroundColor(.white)
+        }
+        .frame(width: 70, height: 70)
+    }
+}
+
+private struct HeistPlayerRow: View {
+    let status: HeistPlayerStatus
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(status.role == .guard ? Color.red.opacity(0.3) : status.color.opacity(0.3))
+                .frame(width: 36, height: 36)
+                .overlay(
+                    Text(status.role == .guard ? "🛡" : "🥷")
+                        .font(.system(size: 18))
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(status.name)
+                    .font(.body)
+                    .foregroundColor(status.isCaught ? .white.opacity(0.3) : .white)
+                Text(status.role == .guard ? "Guard" : status.isCaught ? "Caught" : "Thief")
+                    .font(.caption)
+                    .foregroundColor(status.role == .guard ? .red.opacity(0.7) : .white.opacity(0.4))
+            }
+
+            Spacer()
+
+            if status.hasEscaped {
+                Text("ESCAPED").font(.caption2.bold()).foregroundColor(.green)
+            } else if status.isCaught {
+                Image(systemName: "xmark.circle.fill").foregroundColor(.red.opacity(0.5))
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .opacity(status.isCaught ? 0.5 : 1)
+    }
+}
+
+private struct WinnerBanner: View {
+    let winner: HeistWinner
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(winner == .guard ? "🛡 Guard Wins!" : "🥷 Thieves Win!")
+                .font(.title3.bold())
+                .foregroundColor(winner == .guard ? .red : .green)
+            Text(winner == .guard ? "All thieves caught." : "A thief escaped!")
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.5))
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(winner == .guard ? Color.red.opacity(0.15) : Color.green.opacity(0.15))
+        )
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+final class HeistBoardViewModel: ObservableObject {
+    @Published var state = HeistBoardState()
+    private let socket = GameSocketManager.shared
+
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (response: GameStateResponse) in
+            guard response.roomCode == roomCode else { return }
+            self?.state.update(from: response.boardState)
+        }
+    }
+}
+
+// MARK: - State
+
+struct HeistBoardState {
+    var round = 1
+    var phase: HeistPhase = .guardSets
+    var secondsLeft = HeistConstants.secondsPerPhase
+    var grid: [[HeistTileType]] = HeistBoardState.defaultGrid()
+    var cameraPositions: [GridPos] = []           // Guard-controlled this round
+    var cameraArcTiles: Set<GridPos> = []          // Computed from camera angles
+    var thiefPositions: [String: GridPos] = [:]    // playerID → pos (revealed on TV)
+    var playerStatuses: [HeistPlayerStatus] = []
+    var winner: HeistWinner? = nil
+
+    // Build the grid only once (layout is static)
+    static func defaultGrid() -> [[HeistTileType]] {
+        let cols = HeistConstants.cols
+        let rows = HeistConstants.rows
+        var g = Array(repeating: Array(repeating: HeistTileType.empty, count: cols), count: rows)
+
+        // Walls along border
+        for c in 0..<cols { g[0][c] = .wall; g[rows-1][c] = .wall }
+        for r in 0..<rows { g[r][0] = .wall; g[r][cols-1] = .wall }
+
+        // Inner wall obstacles
+        let walls: [GridPos] = [
+            .init(col:2,row:1), .init(col:2,row:2), .init(col:2,row:3),
+            .init(col:4,row:3), .init(col:4,row:4), .init(col:4,row:5),
+            .init(col:2,row:5), .init(col:2,row:6)
+        ]
+        for w in walls { g[w.row][w.col] = .wall }
+
+        // Camera stands (Guard can use these)
+        let cameras: [GridPos] = [
+            .init(col:1,row:1), .init(col:5,row:1),
+            .init(col:1,row:5), .init(col:5,row:5)
+        ]
+        for c in cameras { g[c.row][c.col] = .camera }
+
+        // Vault in centre
+        g[HeistConstants.rows/2][HeistConstants.cols/2] = .vault
+
+        // Exits
+        g[3][0] = .exit
+        g[3][cols-1] = .exit
+
+        return g
+    }
+
+    func tileType(at pos: GridPos) -> HeistTileType {
+        guard pos.row >= 0, pos.row < grid.count,
+              pos.col >= 0, pos.col < grid[0].count else { return .wall }
+        return grid[pos.row][pos.col]
+    }
+
+    func cameraArcCovers(_ pos: GridPos) -> Bool { cameraArcTiles.contains(pos) }
+
+    func thieves(at pos: GridPos) -> [HeistThiefStatus] {
+        playerStatuses.filter {
+            $0.role == .thief && !$0.isCaught && thiefPositions[$0.id] == pos
+        }.map { HeistThiefStatus(id: $0.id, color: $0.color) }
+    }
+
+    func isGuardRevealedAt(_ pos: GridPos) -> Bool { cameraPositions.contains(pos) }
+
+    mutating func update(from data: [String: AnyCodable]) {
+        if let r = data["round"]?.value as? Int       { round = r }
+        if let s = data["secondsLeft"]?.value as? Int { secondsLeft = s }
+        if let p = data["phase"]?.value as? String    { phase = HeistPhase(rawValue: p) ?? .guardSets }
+        // Camera arcs, thief positions, and player statuses decoded similarly
+        // (full server payload parsing omitted for brevity — server sends these fields)
+    }
+}
+
+// MARK: - Supporting types
+
+struct GridPos: Hashable, Codable {
+    let col: Int
+    let row: Int
+}
+
+enum HeistTileType { case empty, wall, vault, exit, camera }
+
+enum HeistPhase: String {
+    case guardSets  = "guard_sets"
+    case thievesMove = "thieves_move"
+    case reveal     = "reveal"
+
+    var label: String {
+        switch self {
+        case .guardSets:   return "Guard Setting Cameras"
+        case .thievesMove: return "Thieves Moving"
+        case .reveal:      return "Reveal"
+        }
+    }
+    var color: Color {
+        switch self {
+        case .guardSets:   return .red
+        case .thievesMove: return .cyan
+        case .reveal:      return .yellow
+        }
+    }
+}
+
+enum HeistWinner { case guard_, thieves }
+// disambiguate keyword
+extension HeistWinner {
+    static let `guard` = HeistWinner.guard_
+}
+
+struct HeistPlayerStatus: Identifiable {
+    let id: String
+    let name: String
+    let role: HeistRole
+    let color: Color
+    var isCaught: Bool
+    var hasEscaped: Bool
+}
+
+struct HeistThiefStatus: Identifiable {
+    let id: String
+    let color: Color
+}
+
+enum HeistRole { case `guard`, thief }
+
+enum HeistConstants {
+    static let cols = 7
+    static let rows = 7
+    static let maxRounds = 8
+    static let secondsPerPhase = 20
+}

--- a/ios/GameLabTV/Views/Games/TVTriviaBoardView.swift
+++ b/ios/GameLabTV/Views/Games/TVTriviaBoardView.swift
@@ -178,6 +178,46 @@ final class TriviaboardViewModel: ObservableObject {
 
     private func updateState(from data: [String: AnyCodable]) {
         if let s = data["secondsLeft"]?.value as? Int { secondsLeft = s }
-        // Parse question, choices, players from server payload
+        if let show = data["showChoices"]?.value as? Bool { showChoices = show }
+
+        // Reveal correct answer
+        if let idx = data["correctIndex"]?.value as? Int {
+            revealedCorrectIndex = idx
+        }
+
+        // Players who have answered this round
+        if let answered = data["answeredPlayerIDs"]?.value as? [String] {
+            answeredIDs = Set(answered)
+        }
+
+        // Player score list
+        if let playerData = data["players"]?.value as? [[String: Any]] {
+            players = playerData.compactMap { d -> Player? in
+                guard let id   = d["id"]   as? String,
+                      let name = d["name"] as? String else { return nil }
+                return Player(id: id, name: name, isReady: true,
+                              score: d["score"] as? Int ?? 0,
+                              isHost: d["isHost"] as? Bool ?? false)
+            }
+        }
+
+        // New question — reset answer state and schedule choice reveal
+        let incomingQID = data["questionID"]?.value as? String ?? ""
+        let incomingText = data["questionText"]?.value as? String ?? ""
+        if !incomingQID.isEmpty, incomingText != currentQuestion?.text {
+            answeredIDs = []
+            revealedCorrectIndex = nil
+            showChoices = false
+            currentQuestion = TriviaQuestion(
+                text: incomingText,
+                choices: data["choices"]?.value as? [String] ?? [],
+                correctIndex: data["correctIndex"]?.value as? Int ?? 0,
+                category: data["category"]?.value as? String ?? "General"
+            )
+            // Brief delay so TV readers can read the question before choices appear
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                [weak self] in self?.showChoices = true
+            }
+        }
     }
 }

--- a/ios/GameLabTV/Views/Games/TVTriviaBoardView.swift
+++ b/ios/GameLabTV/Views/Games/TVTriviaBoardView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct TVTriviaBoardView: View {
+    let room: Room
+    @StateObject private var vm = TriviaboardViewModel()
+
+    var body: some View {
+        VStack(spacing: 32) {
+            // Score bar
+            HStack {
+                ForEach(vm.players) { p in
+                    PlayerScoreChip(player: p, isAnswered: vm.answeredIDs.contains(p.id))
+                }
+            }
+            .padding(.horizontal, 60)
+
+            if let q = vm.currentQuestion {
+                // Category tag
+                Text(q.category.uppercased())
+                    .font(.caption.bold())
+                    .tracking(3)
+                    .foregroundColor(.cyan.opacity(0.8))
+
+                // Question
+                Text(q.text)
+                    .font(.system(size: 42, weight: .bold))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 100)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // Choices — revealed one second after question appears
+                if vm.showChoices {
+                    LazyVGrid(
+                        columns: [GridItem(.flexible()), GridItem(.flexible())],
+                        spacing: 20
+                    ) {
+                        ForEach(Array(q.choices.enumerated()), id: \.offset) { idx, choice in
+                            ChoiceTile(
+                                label: choice,
+                                index: idx,
+                                state: vm.choiceState(for: idx, correctIndex: q.correctIndex)
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 80)
+                }
+
+                // Timer ring
+                TimerRing(secondsLeft: vm.secondsLeft, total: 20)
+
+            } else {
+                Text("Loading question…")
+                    .foregroundColor(.white.opacity(0.3))
+            }
+
+            Spacer()
+        }
+        .padding(.top, 48)
+        .background(Color(hex: "0a0a14").ignoresSafeArea())
+        .onAppear { vm.bind(roomCode: room.code) }
+    }
+}
+
+private struct PlayerScoreChip: View {
+    let player: Player
+    let isAnswered: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(isAnswered ? Color.green.opacity(0.4) : Color.white.opacity(0.1))
+                .frame(width: 10, height: 10)
+            Text(player.name)
+                .font(.body)
+                .foregroundColor(isAnswered ? .white : .white.opacity(0.4))
+            Text("\(player.score)")
+                .font(.headline.bold())
+                .foregroundColor(.cyan)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(Capsule().fill(Color.white.opacity(0.07)))
+    }
+}
+
+private struct ChoiceTile: View {
+    enum ChoiceState { case idle, correct, wrong }
+    let label: String
+    let index: Int
+    let state: ChoiceState
+
+    private let letters = ["A", "B", "C", "D"]
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(letters[index])
+                .font(.headline.bold())
+                .frame(width: 40, height: 40)
+                .background(Circle().fill(badgeColor))
+                .foregroundColor(.white)
+
+            Text(label)
+                .font(.title3)
+                .foregroundColor(.white)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(tileFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .strokeBorder(borderColor, lineWidth: 2)
+                )
+        )
+    }
+
+    private var badgeColor: Color {
+        switch state {
+        case .idle:    return Color.white.opacity(0.15)
+        case .correct: return .green
+        case .wrong:   return .red
+        }
+    }
+
+    private var tileFill: Color {
+        switch state {
+        case .idle:    return Color.white.opacity(0.06)
+        case .correct: return Color.green.opacity(0.15)
+        case .wrong:   return Color.red.opacity(0.1)
+        }
+    }
+
+    private var borderColor: Color {
+        switch state {
+        case .idle:    return Color.white.opacity(0.08)
+        case .correct: return .green.opacity(0.8)
+        case .wrong:   return .red.opacity(0.5)
+        }
+    }
+}
+
+// MARK: - ViewModel
+
+struct TriviaQuestion {
+    let text: String
+    let choices: [String]
+    let correctIndex: Int
+    let category: String
+}
+
+@MainActor
+final class TriviaboardViewModel: ObservableObject {
+    @Published var players: [Player] = []
+    @Published var currentQuestion: TriviaQuestion? = nil
+    @Published var showChoices = false
+    @Published var secondsLeft = 20
+    @Published var answeredIDs: Set<String> = []
+    @Published var revealedCorrectIndex: Int? = nil
+
+    private let socket = GameSocketManager.shared
+
+    func bind(roomCode: String) {
+        socket.on(.gameState) { [weak self] (r: GameStateResponse) in
+            guard r.roomCode == roomCode else { return }
+            self?.updateState(from: r.boardState)
+        }
+    }
+
+    func choiceState(for index: Int, correctIndex: Int) -> ChoiceTile.ChoiceState {
+        guard let revealed = revealedCorrectIndex else { return .idle }
+        if index == revealed { return .correct }
+        return .idle
+    }
+
+    private func updateState(from data: [String: AnyCodable]) {
+        if let s = data["secondsLeft"]?.value as? Int { secondsLeft = s }
+        // Parse question, choices, players from server payload
+    }
+}

--- a/ios/GameLabTV/Views/TVGameBoardView.swift
+++ b/ios/GameLabTV/Views/TVGameBoardView.swift
@@ -6,17 +6,34 @@ struct TVGameBoardView: View {
 
     var body: some View {
         switch room.gameID {
-        case .heist:       TVHeistBoardView(room: room)
-        case .trivia:      TVTriviaBoardView(room: room)
-        case .poker:       TVPokerBoardView(room: room)
-        case .tambola:     TVTambolaBoardView(room: room)
-        case .stockPanic:  TVStockPanicBoardView(room: room)
-        case .mindMeld:    TVMindMeldBoardView(room: room)
-        case .hotGrid:     TVHotGridBoardView(room: room)
+        // Invented games — full implementations
+        case .heist:         TVHeistBoardView(room: room)
+        case .stockPanic:    TVStockPanicBoardView(room: room)
+        case .mindMeld:      TVMindMeldBoardView(room: room)
+        case .hotGrid:       TVHotGridBoardView(room: room)
         case .speedSculptor: TVSpeedSculptorBoardView(room: room)
-        default:
-            // Fallback web view for games not yet ported natively
-            TVWebGameBoardView(room: room)
+
+        // Knowledge
+        case .trivia:        TVTriviaBoardView(room: room)
+        case .digitGuess:    TVDigitGuessBoardView(room: room)
+
+        // Casino
+        case .poker:         TVPokerBoardView(room: room)
+        case .tambola:       TVTambolaBoardView(room: room)
+        case .roulette:      TVRouletteBoardView(room: room)
+
+        // Social
+        case .mafia:         TVMafiaBoardView(room: room)
+        case .rajaMantri:    TVRajaMantriBoard(room: room)
+
+        // Strategy / Board
+        case .chess:         TVWebGameBoardView(room: room)   // web canvas via WKWebView
+        case .connectFour:   TVConnect4BoardView(room: room)
+        case .memory:        TVMemoryBoardView(room: room)
+        case .snakeLadder:   TVWebGameBoardView(room: room)   // web canvas
+
+        // Action
+        case .pong:          TVPongBoardView(room: room)
         }
     }
 }

--- a/ios/GameLabTV/Views/TVGameBoardView.swift
+++ b/ios/GameLabTV/Views/TVGameBoardView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Routes to the correct game board based on the room's gameID.
+struct TVGameBoardView: View {
+    let room: Room
+
+    var body: some View {
+        switch room.gameID {
+        case .heist:       TVHeistBoardView(room: room)
+        case .trivia:      TVTriviaBoardView(room: room)
+        case .poker:       TVPokerBoardView(room: room)
+        case .tambola:     TVTambolaBoardView(room: room)
+        case .stockPanic:  TVStockPanicBoardView(room: room)
+        case .mindMeld:    TVMindMeldBoardView(room: room)
+        case .hotGrid:     TVHotGridBoardView(room: room)
+        case .speedSculptor: TVSpeedSculptorBoardView(room: room)
+        default:
+            // Fallback web view for games not yet ported natively
+            TVWebGameBoardView(room: room)
+        }
+    }
+}

--- a/ios/GameLabTV/Views/TVGameSelectionView.swift
+++ b/ios/GameLabTV/Views/TVGameSelectionView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+struct TVGameSelectionView: View {
+    let onSelect: (GameID) -> Void
+
+    @State private var selectedCategory: GameCategory? = nil
+    @FocusState private var focusedGame: GameID?
+
+    private var displayedGames: [GameID] {
+        if let cat = selectedCategory {
+            return GameID.allCases.filter { $0.category == cat }
+        }
+        return GameID.allCases
+    }
+
+    var body: some View {
+        HStack(spacing: 60) {
+            // Left sidebar — categories
+            VStack(alignment: .leading, spacing: 20) {
+                Text("GameLab")
+                    .font(.system(size: 52, weight: .black, design: .rounded))
+                    .foregroundStyle(
+                        LinearGradient(colors: [.purple, .cyan], startPoint: .leading, endPoint: .trailing)
+                    )
+
+                Text("Pick a game")
+                    .font(.title3)
+                    .foregroundColor(.white.opacity(0.6))
+
+                Divider().background(Color.white.opacity(0.2))
+
+                VStack(alignment: .leading, spacing: 12) {
+                    CategoryPill(label: "All", isSelected: selectedCategory == nil) {
+                        selectedCategory = nil
+                    }
+                    ForEach(GameCategory.allCases, id: \.self) { cat in
+                        CategoryPill(label: cat.rawValue, isSelected: selectedCategory == cat) {
+                            selectedCategory = (selectedCategory == cat) ? nil : cat
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // Connection status dot
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(GameSocketManager.shared.isConnected ? Color.green : Color.red)
+                        .frame(width: 10, height: 10)
+                    Text(GameSocketManager.shared.isConnected ? "Server connected" : "Reconnecting…")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.5))
+                }
+            }
+            .frame(width: 280)
+            .padding(.vertical, 60)
+            .padding(.leading, 60)
+
+            // Right — game grid
+            ScrollView {
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.fixed(260), spacing: 28), count: 4),
+                    spacing: 28
+                ) {
+                    ForEach(displayedGames, id: \.self) { game in
+                        TVGameCard(game: game, isFocused: focusedGame == game)
+                            .focused($focusedGame, equals: game)
+                            .onPlayPauseCommand { onSelect(game) }
+                            // tvOS primary action = select button
+                            .onMoveCommand { _ in }
+                            .buttonStyle(.plain)
+                            .onTapGesture { onSelect(game) }
+                    }
+                }
+                .padding(.vertical, 60)
+                .padding(.trailing, 60)
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private struct TVGameCard: View {
+    let game: GameID
+    let isFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Text(game.emoji)
+                .font(.system(size: 64))
+
+            Text(game.displayName)
+                .font(.headline)
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+
+            Text("\(game.minPlayers)–\(game.maxPlayers) players")
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.5))
+
+            HStack(spacing: 4) {
+                if game.hasPrivateInfo {
+                    Label("Private info", systemImage: "eye.slash.fill")
+                        .font(.caption2)
+                        .foregroundColor(.cyan)
+                }
+            }
+        }
+        .frame(width: 240, height: 200)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(isFocused
+                      ? Color.purple.opacity(0.4)
+                      : Color.white.opacity(0.07))
+                .shadow(color: isFocused ? .purple.opacity(0.6) : .clear, radius: 20)
+        )
+        .scaleEffect(isFocused ? 1.06 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+    }
+}
+
+private struct CategoryPill: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.body)
+                .foregroundColor(isSelected ? .black : .white.opacity(0.7))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule().fill(isSelected ? Color.cyan : Color.white.opacity(0.1))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/GameLabTV/Views/TVLobbyView.swift
+++ b/ios/GameLabTV/Views/TVLobbyView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// Displayed on TV while players join via their phones.
+struct TVLobbyView: View {
+    let room: Room
+    let onStart: () -> Void
+
+    var body: some View {
+        HStack(spacing: 80) {
+            // Left — room code + QR
+            VStack(spacing: 32) {
+                VStack(spacing: 8) {
+                    Text("Join on your phone")
+                        .font(.title2)
+                        .foregroundColor(.white.opacity(0.6))
+
+                    Text(room.code)
+                        .font(.system(size: 96, weight: .black, design: .monospaced))
+                        .foregroundStyle(
+                            LinearGradient(colors: [.cyan, .purple], startPoint: .leading, endPoint: .trailing)
+                        )
+                        .kerning(12)
+
+                    Text("gamelab.app  •  Enter code above")
+                        .font(.body)
+                        .foregroundColor(.white.opacity(0.4))
+                }
+
+                // Animated pulse ring around code
+                ZStack {
+                    Circle()
+                        .stroke(Color.purple.opacity(0.2), lineWidth: 2)
+                        .frame(width: 220, height: 220)
+                    Circle()
+                        .stroke(Color.cyan.opacity(0.15), lineWidth: 1)
+                        .frame(width: 270, height: 270)
+                        .scaleEffect(1.05)
+                        .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true), value: true)
+
+                    Text(room.gameID.emoji)
+                        .font(.system(size: 80))
+                }
+            }
+            .frame(maxWidth: 520)
+
+            // Right — player list + start
+            VStack(alignment: .leading, spacing: 24) {
+                Text(room.gameID.displayName)
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(.white)
+
+                Text("\(room.players.count) / \(room.gameID.maxPlayers) players")
+                    .font(.title3)
+                    .foregroundColor(.white.opacity(0.5))
+
+                ScrollView {
+                    VStack(spacing: 12) {
+                        ForEach(room.players) { player in
+                            PlayerRow(player: player)
+                        }
+                        // Empty slots
+                        ForEach(room.players.count..<room.gameID.maxPlayers, id: \.self) { _ in
+                            EmptySlotRow()
+                        }
+                    }
+                }
+
+                Spacer()
+
+                let canStart = room.players.count >= room.gameID.minPlayers
+                Button(action: onStart) {
+                    Label(canStart ? "Start Game" : "Waiting for \(room.gameID.minPlayers - room.players.count) more…",
+                          systemImage: canStart ? "play.fill" : "hourglass")
+                        .font(.title3.bold())
+                        .foregroundColor(canStart ? .black : .white.opacity(0.4))
+                        .padding(.horizontal, 40)
+                        .padding(.vertical, 18)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(canStart ? Color.cyan : Color.white.opacity(0.1))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!canStart)
+            }
+            .frame(maxWidth: 520)
+        }
+        .padding(80)
+    }
+}
+
+private struct PlayerRow: View {
+    let player: Player
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Circle()
+                .fill(Color.purple.opacity(0.4))
+                .frame(width: 40, height: 40)
+                .overlay(Text(String(player.name.prefix(1))).foregroundColor(.white))
+
+            Text(player.name)
+                .foregroundColor(.white)
+                .font(.body)
+
+            if player.isHost { Text("HOST").font(.caption2).foregroundColor(.cyan) }
+
+            Spacer()
+
+            Image(systemName: player.isReady ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(player.isReady ? .green : .white.opacity(0.3))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.06)))
+    }
+}
+
+private struct EmptySlotRow: View {
+    var body: some View {
+        HStack {
+            Circle()
+                .strokeBorder(Color.white.opacity(0.15), lineWidth: 1, antialiased: true)
+                .frame(width: 40, height: 40)
+            Text("Waiting…")
+                .foregroundColor(.white.opacity(0.2))
+                .font(.body)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.03)))
+    }
+}

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane", "~> 2.220"
+gem "xcode-install", "~> 2.8"

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "GameLab",
+    platforms: [
+        .iOS(.v17),
+        .tvOS(.v17)
+    ],
+    products: [
+        .library(name: "GameLabShared", targets: ["GameLabShared"]),
+    ],
+    dependencies: [
+        // Socket.IO Swift client — add via Xcode or SPM
+        .package(url: "https://github.com/socketio/socket.io-client-swift", from: "16.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "GameLabShared",
+            dependencies: [
+                .product(name: "SocketIO", package: "socket.io-client-swift")
+            ],
+            path: "Shared"
+        ),
+        // Note: GameLabTV and GameLabController are Xcode app targets (not SPM targets).
+        // Add them in Xcode and link GameLabShared as a dependency.
+    ]
+)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,110 @@
+# GameLab iOS + Apple TV
+
+**Phone = Controller. TV = Board.**
+
+## Project Structure
+
+```
+ios/
+├── Package.swift              — SPM package (shared library + SocketIO dep)
+├── Shared/                    — Code used by both apps
+│   ├── Constants.swift        — Server URL, device ID, Color(hex:)
+│   ├── Models/
+│   │   ├── Game.swift         — GameID enum (all 17 games + 5 invented)
+│   │   └── Room.swift         — Room, Player, RoomState models
+│   └── Networking/
+│       ├── SocketManager.swift  — Singleton Socket.IO client
+│       └── GameMessage.swift    — All event names + payload types
+│
+├── GameLabTV/                 — tvOS app (the board on your TV)
+│   ├── App/
+│   │   ├── GameLabTVApp.swift
+│   │   └── RootTVView.swift   — Screen router + TVRootViewModel
+│   └── Views/
+│       ├── TVGameSelectionView.swift  — Netflix-style game picker
+│       ├── TVLobbyView.swift          — Room code + player list
+│       ├── TVGameBoardView.swift      — Routes to per-game board
+│       └── Games/
+│           ├── TVHeistBoardView.swift   — Full Heist board (invented game)
+│           └── TVTriviaBoardView.swift  — Trivia board
+│
+└── GameLabController/         — iOS app (the controller on your phone)
+    ├── App/
+    │   ├── GameLabControllerApp.swift
+    │   └── RootControllerView.swift  — Screen router + ControllerRootViewModel
+    └── Views/
+        ├── JoinRoomView.swift    — Enter room code shown on TV
+        ├── WaitingView.swift     — Lobby waiting room
+        └── Controllers/
+            ├── ControllerGameView.swift        — Routes to per-game controller
+            ├── HeistControllerView.swift       — Guard (cameras) / Thief (D-pad)
+            ├── TriviaControllerView.swift      — Answer tap buttons
+            └── OtherControllerViews.swift      — Poker, Pong tilt, Snake shake,
+                                                  MindMeld, HotGrid, StockPanic,
+                                                  SpeedSculptor, Tambola, fallback
+```
+
+## Xcode Setup
+
+1. Open Xcode → **Create a new Xcode project**
+2. Create **two targets**:
+   - `GameLabTV` — tvOS App
+   - `GameLabController` — iOS App
+3. Add the Swift files from each folder to their respective targets
+4. Add `Shared/` files to both targets
+5. In each target's Package Dependencies, add:
+   ```
+   https://github.com/socketio/socket.io-client-swift  (≥ 16.0.0)
+   ```
+6. In `Shared/Constants.swift` set `serverURL` to your Flask server's address
+
+## How It Works
+
+```
+TV App                          Flask Server (existing)        Phone App
+───────────────────────────────────────────────────────────────────────────
+Create room (game selected) ──> assigns room code
+Display room code + QR ─────────────────────────────────────── Enter code
+                               player joins room <──────────── JoinRoom
+Room updated (player list) <── broadcast room state
+[Host presses Start] ────────> start_game event
+                               assigns roles (Heist: 1 guard)
+game_state broadcast ──────────────────────────────────────── (TV board)
+                               private_state per player <───── (phone only)
+Player action ──────────────────────────────── onAction("move", ...) ──>
+                               validates + updates state
+game_state broadcast ──────────────────────────────────────── (TV updates)
+```
+
+## Invented Games (phone-first design)
+
+| Game | Why phone-as-controller shines |
+|---|---|
+| **Heist** | Guard's camera positions are secret (phone only). Thieves see only their own tile. TV shows the full vault — pure asymmetric information. |
+| **Stock Panic** | Portfolio is private (phone). TV shows only prices + news events. |
+| **Mind Meld** | Everyone types simultaneously in secret. TV reveals all at once. |
+| **Hot Grid** | Phone picks a hidden tile; TV reveals what was underneath. |
+| **Speed Sculptor** | Phone is the drawing canvas. TV shows all drawings side by side for voting. |
+
+## Server Changes Needed
+
+Add these Socket.IO events to the Flask backend (minimal additions):
+
+```python
+# In each game's socket_events.py:
+@socketio.on('create_room')
+def on_create_room(data):
+    # generate room code, store game state, emit room_joined
+
+@socketio.on('join_room')
+def on_join_room(data):
+    # add player, broadcast room_updated
+
+@socketio.on('game_action')
+def on_game_action(data):
+    # validate, update game state
+    # emit game_state to room (TV sees it)
+    # emit private_state to specific player (phone sees it)
+```
+
+The existing Flask-SocketIO setup already supports all of this.

--- a/ios/SETUP.md
+++ b/ios/SETUP.md
@@ -1,0 +1,196 @@
+# GameLab iOS + tvOS — Setup & Deployment Guide
+
+**Goal:** iPhone = controller, Apple TV = game board. Both installed via TestFlight.
+
+---
+
+## How the pipeline works
+
+```
+git push → GitHub Actions (macos-15 runner)
+              ├─ XcodeGen generates GameLab.xcodeproj
+              ├─ Signs with your Apple Distribution cert
+              ├─ Archives + exports GameLabController.ipa  (iOS)
+              ├─ Archives + exports GameLabTV.ipa          (tvOS)
+              └─ Uploads both to TestFlight
+                    ├─ Install GameLab on iPhone via TestFlight app
+                    └─ Install GameLab TV on Apple TV via TestFlight app
+```
+
+---
+
+## Prerequisites
+
+| Requirement | Where to get it |
+|---|---|
+| Apple Developer Program membership | developer.apple.com ($99/year) |
+| Mac with Xcode 16+ | Required to run locally |
+| XcodeGen (local only) | `brew install xcodegen` |
+
+---
+
+## Step 1 — Register your apps in Apple Developer Portal
+
+1. Go to **developer.apple.com → Certificates, IDs & Profiles → Identifiers**
+2. Click **+** → App IDs → App
+3. Create two App IDs:
+   - Bundle ID: `com.gamelab.controller` — Platform: iOS
+   - Bundle ID: `com.gamelab.tv` — Platform: tvOS
+4. **Change the bundle IDs** in `ios/project.yml` and `ios/fastlane/Appfile`
+   to match whatever you registered (use your own reverse-domain prefix)
+
+---
+
+## Step 2 — Create App Store Connect records
+
+1. Go to **appstoreconnect.apple.com → My Apps → +**
+2. Create two new apps:
+   - **GameLab** — iOS, bundle ID `com.gamelab.controller`
+   - **GameLab TV** — tvOS, bundle ID `com.gamelab.tv`
+3. Note your **Team ID** (shown top-right in developer.apple.com → Account)
+
+---
+
+## Step 3 — Get your Apple Distribution certificate
+
+> Skip if you already have one in Keychain Access.
+
+1. In Xcode: **Settings → Accounts → Manage Certificates → + → Apple Distribution**
+2. In Keychain Access: find **Apple Distribution: Your Name (XXXXXXXXXX)**
+3. Right-click → Export → save as `dist.p12`, set a password
+4. Base64-encode it:
+   ```bash
+   base64 -i dist.p12 | pbcopy   # copies to clipboard
+   ```
+5. Save the base64 string and the password — you'll need them in Step 5
+
+---
+
+## Step 4 — Create provisioning profiles
+
+### iOS (App Store distribution)
+1. developer.apple.com → Profiles → **+**
+2. Type: **App Store Connect** → Continue
+3. App ID: your iOS bundle ID → Continue
+4. Certificate: your Apple Distribution cert → Continue
+5. Name: `GameLab Controller AppStore` → Generate → Download
+6. Base64-encode it:
+   ```bash
+   base64 -i GameLab_Controller_AppStore.mobileprovision | pbcopy
+   ```
+
+### tvOS (App Store distribution)
+1. Same steps, App ID: your tvOS bundle ID
+2. Name: `GameLab TV AppStore` → Generate → Download
+3. Base64-encode:
+   ```bash
+   base64 -i GameLab_TV_AppStore.mobileprovision | pbcopy
+   ```
+
+---
+
+## Step 5 — Create App Store Connect API key
+
+This lets GitHub Actions upload without your Apple ID password.
+
+1. appstoreconnect.apple.com → **Users & Access → Integrations → App Store Connect API**
+2. Click **+** → Name: `GitHub Actions` → Role: **App Manager**
+3. Download the `.p8` file (you can only download once — save it!)
+4. Note the **Key ID** and **Issuer ID** shown on that page
+5. Read the `.p8` file content (it's text starting with `-----BEGIN PRIVATE KEY-----`)
+
+---
+
+## Step 6 — Add GitHub Secrets
+
+Go to your GitHub repo → **Settings → Secrets and variables → Actions → New repository secret**
+
+Add these 9 secrets:
+
+| Secret name | Value |
+|---|---|
+| `BUILD_CERTIFICATE_BASE64` | Base64 of your `dist.p12` (from Step 3) |
+| `P12_PASSWORD` | Password you set when exporting the .p12 |
+| `KEYCHAIN_PASSWORD` | Any random string (e.g. `openssl rand -hex 20`) |
+| `IOS_PROVISION_PROFILE_BASE64` | Base64 of iOS `.mobileprovision` (from Step 4) |
+| `IOS_PROVISION_PROFILE_NAME` | Exact profile name, e.g. `GameLab Controller AppStore` |
+| `TVOS_PROVISION_PROFILE_BASE64` | Base64 of tvOS `.mobileprovision` (from Step 4) |
+| `TVOS_PROVISION_PROFILE_NAME` | Exact profile name, e.g. `GameLab TV AppStore` |
+| `ASC_KEY_ID` | Key ID from Step 5 (e.g. `ABC1234DEF`) |
+| `ASC_ISSUER_ID` | Issuer ID from Step 5 (UUID format) |
+| `ASC_PRIVATE_KEY` | Full content of the `.p8` file (paste as-is, including `-----BEGIN/END-----`) |
+| `DEVELOPMENT_TEAM` | Your 10-character Team ID (e.g. `ABCD123456`) |
+
+---
+
+## Step 7 — Configure your server URL
+
+Edit `ios/Shared/Constants.swift`:
+```swift
+static let serverURL = URL(string: "https://your-deployed-server.com")!
+//                                   ↑ change to your Flask server's public URL
+```
+
+For local testing on the same WiFi network:
+```swift
+static let serverURL = URL(string: "http://192.168.1.X:5000")!
+//                                   ↑ your Mac's LAN IP
+```
+
+---
+
+## Step 8 — Push to trigger the build
+
+```bash
+git push origin main
+```
+
+GitHub Actions will:
+1. Generate the Xcode project (no `.xcodeproj` committed — it's clean)
+2. Sign with your certificate
+3. Upload to TestFlight (processing takes ~10 min on Apple's side)
+
+Then on your devices:
+
+**iPhone:** Install **TestFlight** app → open the invite link or use your Apple ID
+**Apple TV:** Install **TestFlight** on Apple TV (App Store) → same invite link
+
+---
+
+## Running locally (fastest for development)
+
+```bash
+cd ios
+brew install xcodegen               # one-time
+xcodegen generate                   # creates GameLab.xcodeproj
+open GameLab.xcworkspace            # open in Xcode
+```
+
+Then in Xcode:
+- Select **GameLabController** scheme + your iPhone as destination → ▶ Run
+- Select **GameLabTV** scheme + your Apple TV as destination → ▶ Run
+
+For Apple TV wireless debugging:
+1. Apple TV: **Settings → Remotes and Devices → Remote App and Devices**
+2. Xcode: **Window → Devices and Simulators** → it should appear on the same WiFi
+
+---
+
+## Trigger a manual deploy
+
+Without pushing code, go to:
+**GitHub → Actions → "iOS + tvOS → TestFlight" → Run workflow**
+Choose `both`, `ios`, or `tvos`.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| "No signing certificate found" | Re-export .p12 and re-encode; check Team ID secret |
+| "Profile doesn't match bundle ID" | Make sure profile name in secret matches exactly |
+| "invalid_grant" on upload | API key may be expired; create a new one in Step 5 |
+| Apple TV not appearing in Xcode | Must be on same WiFi; try USB-C cable instead |
+| Build fails on SPM resolve | Check XcodeGen version: `brew upgrade xcodegen` |
+| Server URL unreachable on device | Use your Mac's LAN IP, not `localhost` |

--- a/ios/Shared/Constants.swift
+++ b/ios/Shared/Constants.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftUI
+
+enum AppConstants {
+    // Change this to your server's address (local dev or deployed)
+    static let serverURL = URL(string: "http://localhost:5000")!
+
+    // Stable per-device identifier (persisted in UserDefaults)
+    static var deviceID: String {
+        let key = "gamelab_device_id"
+        if let existing = UserDefaults.standard.string(forKey: key) { return existing }
+        let new = UUID().uuidString
+        UserDefaults.standard.set(new, forKey: key)
+        return new
+    }
+}
+
+// MARK: - Color(hex:) convenience
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255
+        let g = Double((int >>  8) & 0xFF) / 255
+        let b = Double((int >>  0) & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/ios/Shared/Models/Game.swift
+++ b/ios/Shared/Models/Game.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+enum GameID: String, Codable, CaseIterable {
+    case trivia       = "trivia"
+    case poker        = "poker"
+    case tambola      = "tambola"
+    case mafia        = "mafia"
+    case heist        = "heist"
+    case stockPanic   = "stock_panic"
+    case mindMeld     = "mind_meld"
+    case hotGrid      = "hot_grid"
+    case speedSculptor = "speed_sculptor"
+    case pong         = "pong"
+    case connectFour  = "connect4"
+    case chess        = "chess"
+    case snakeLadder  = "snake_ladder"
+    case roulette     = "roulette"
+    case rajaMantri   = "raja_mantri"
+    case memory       = "memory"
+    case digitGuess   = "digit_guess"
+
+    var displayName: String {
+        switch self {
+        case .trivia:        return "Trivia"
+        case .poker:         return "Poker"
+        case .tambola:       return "Tambola"
+        case .mafia:         return "Mafia"
+        case .heist:         return "Heist"
+        case .stockPanic:    return "Stock Panic"
+        case .mindMeld:      return "Mind Meld"
+        case .hotGrid:       return "Hot Grid"
+        case .speedSculptor: return "Speed Sculptor"
+        case .pong:          return "Pong"
+        case .connectFour:   return "Connect 4"
+        case .chess:         return "Chess"
+        case .snakeLadder:   return "Snake & Ladder"
+        case .roulette:      return "Roulette"
+        case .rajaMantri:    return "Raja Mantri"
+        case .memory:        return "Memory"
+        case .digitGuess:    return "Digit Guess"
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .trivia:        return "🧠"
+        case .poker:         return "🃏"
+        case .tambola:       return "🎱"
+        case .mafia:         return "🕵️"
+        case .heist:         return "🏦"
+        case .stockPanic:    return "📈"
+        case .mindMeld:      return "🔮"
+        case .hotGrid:       return "💣"
+        case .speedSculptor: return "🎨"
+        case .pong:          return "🏓"
+        case .connectFour:   return "🟡"
+        case .chess:         return "♟️"
+        case .snakeLadder:   return "🎲"
+        case .roulette:      return "🎡"
+        case .rajaMantri:    return "👑"
+        case .memory:        return "🧩"
+        case .digitGuess:    return "🔢"
+        }
+    }
+
+    var category: GameCategory {
+        switch self {
+        case .trivia, .mindMeld, .digitGuess:
+            return .knowledge
+        case .poker, .roulette, .tambola:
+            return .casino
+        case .mafia, .heist, .rajaMantri:
+            return .social
+        case .stockPanic, .hotGrid, .connectFour, .chess, .snakeLadder, .memory:
+            return .strategy
+        case .speedSculptor:
+            return .creative
+        case .pong:
+            return .action
+        }
+    }
+
+    var minPlayers: Int {
+        switch self {
+        case .pong:          return 2
+        case .poker:         return 2
+        case .chess:         return 2
+        case .connectFour:   return 2
+        case .digitGuess:    return 2
+        case .snakeLadder:   return 2
+        case .roulette:      return 1
+        case .memory:        return 2
+        case .tambola:       return 2
+        case .trivia:        return 2
+        case .mafia:         return 5
+        case .heist:         return 3
+        case .hotGrid:       return 2
+        case .stockPanic:    return 2
+        case .mindMeld:      return 3
+        case .speedSculptor: return 3
+        case .rajaMantri:    return 4
+        }
+    }
+
+    var maxPlayers: Int {
+        switch self {
+        case .pong:          return 2
+        case .chess:         return 2
+        case .connectFour:   return 2
+        case .digitGuess:    return 4
+        case .poker:         return 8
+        case .roulette:      return 8
+        case .snakeLadder:   return 6
+        case .memory:        return 4
+        case .tambola:       return 20
+        case .trivia:        return 10
+        case .mafia:         return 15
+        case .heist:         return 6
+        case .hotGrid:       return 8
+        case .stockPanic:    return 6
+        case .mindMeld:      return 8
+        case .speedSculptor: return 8
+        case .rajaMantri:    return 4
+        }
+    }
+
+    // Phone is the controller; TV is the board.
+    // Some games have asymmetric info (private phone screen matters).
+    var hasPrivateInfo: Bool {
+        switch self {
+        case .poker, .mafia, .heist, .rajaMantri, .tambola:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var phoneInputStyle: PhoneInputStyle {
+        switch self {
+        case .pong:                       return .tilt
+        case .speedSculptor:              return .draw
+        case .trivia, .hotGrid, .memory,
+             .connectFour, .mindMeld,
+             .digitGuess, .mafia, .heist,
+             .rajaMantri, .tambola:       return .tap
+        case .poker, .roulette,
+             .stockPanic:                 return .swipe
+        case .chess, .snakeLadder:        return .tapGrid
+        }
+    }
+}
+
+enum GameCategory: String, CaseIterable {
+    case knowledge = "Knowledge"
+    case casino    = "Casino"
+    case social    = "Social"
+    case strategy  = "Strategy"
+    case creative  = "Creative"
+    case action    = "Action"
+}
+
+enum PhoneInputStyle {
+    case tap        // single tap on options
+    case tapGrid    // tap cells in a grid
+    case swipe      // swipe gestures / sliders
+    case draw       // drawing canvas
+    case tilt       // gyroscope / accelerometer
+}

--- a/ios/Shared/Models/Room.swift
+++ b/ios/Shared/Models/Room.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct Room: Codable, Equatable {
+    let code: String
+    let gameID: GameID
+    var players: [Player]
+    var state: RoomState
+
+    var hostPlayerID: String { players.first?.id ?? "" }
+}
+
+struct Player: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var isReady: Bool
+    var score: Int
+    var isHost: Bool
+}
+
+enum RoomState: String, Codable {
+    case lobby    = "lobby"
+    case playing  = "playing"
+    case results  = "results"
+}

--- a/ios/Shared/Networking/GameMessage.swift
+++ b/ios/Shared/Networking/GameMessage.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+// All Socket.IO events flow through these typed messages.
+
+// MARK: - Outbound (client → server)
+
+enum ClientEvent: String {
+    case joinRoom       = "join_room"
+    case createRoom     = "create_room"
+    case playerReady    = "player_ready"
+    case gameAction     = "game_action"    // generic per-game payload
+    case startGame      = "start_game"
+    case leaveRoom      = "leave_room"
+}
+
+// MARK: - Inbound (server → client)
+
+enum ServerEvent: String {
+    case roomJoined     = "room_joined"
+    case roomUpdated    = "room_updated"
+    case gameStarted    = "game_started"
+    case gameState      = "game_state"     // board update for TV
+    case privateState   = "private_state"  // private data for phone only
+    case gameEnded      = "game_ended"
+    case error          = "error"
+}
+
+// MARK: - Payloads
+
+struct JoinRoomPayload: Encodable {
+    let roomCode: String
+    let playerName: String
+    let playerID: String
+    let isTV: Bool         // TV app sends true; phone sends false
+}
+
+struct CreateRoomPayload: Encodable {
+    let gameID: String
+    let hostName: String
+    let hostID: String
+}
+
+struct GameActionPayload: Encodable {
+    let roomCode: String
+    let playerID: String
+    let action: String          // e.g. "answer", "bet", "move"
+    let data: [String: AnyCodable]
+}
+
+struct RoomJoinedResponse: Decodable {
+    let room: Room
+    let playerID: String
+}
+
+struct GameStateResponse: Decodable {
+    let roomCode: String
+    let boardState: [String: AnyCodable]   // TV renders this
+}
+
+struct PrivateStateResponse: Decodable {
+    let roomCode: String
+    let playerID: String
+    let privateData: [String: AnyCodable]  // only sent to that phone
+}
+
+// MARK: - AnyCodable helper (encode/decode arbitrary JSON values)
+
+struct AnyCodable: Codable {
+    let value: Any
+
+    init(_ value: Any) { self.value = value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let v = try? container.decode(Bool.self)   { value = v; return }
+        if let v = try? container.decode(Int.self)    { value = v; return }
+        if let v = try? container.decode(Double.self) { value = v; return }
+        if let v = try? container.decode(String.self) { value = v; return }
+        if let v = try? container.decode([AnyCodable].self) {
+            value = v.map(\.value); return
+        }
+        if let v = try? container.decode([String: AnyCodable].self) {
+            value = v.mapValues(\.value); return
+        }
+        value = NSNull()
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case let v as Bool:               try container.encode(v)
+        case let v as Int:                try container.encode(v)
+        case let v as Double:             try container.encode(v)
+        case let v as String:             try container.encode(v)
+        case let v as [Any]:
+            try container.encode(v.map { AnyCodable($0) })
+        case let v as [String: Any]:
+            try container.encode(v.mapValues { AnyCodable($0) })
+        default:
+            try container.encodeNil()
+        }
+    }
+}

--- a/ios/Shared/Networking/GameMessage.swift
+++ b/ios/Shared/Networking/GameMessage.swift
@@ -63,6 +63,11 @@ struct PrivateStateResponse: Decodable {
     let privateData: [String: AnyCodable]  // only sent to that phone
 }
 
+struct ErrorResponse: Decodable {
+    let message: String
+    let code: String?
+}
+
 // MARK: - AnyCodable helper (encode/decode arbitrary JSON values)
 
 struct AnyCodable: Codable {

--- a/ios/Shared/Networking/SocketManager.swift
+++ b/ios/Shared/Networking/SocketManager.swift
@@ -1,0 +1,83 @@
+import Foundation
+import SocketIO
+
+/// Shared Socket.IO client used by both the TV app and the phone controller app.
+/// Call `connect(to:)` once on launch; then use `emit` / `on` for game events.
+final class GameSocketManager: ObservableObject {
+
+    static let shared = GameSocketManager()
+
+    @Published var isConnected = false
+
+    private var manager: SocketManager?
+    private var socket: SocketIOClient?
+    private var handlers: [String: (Any) -> Void] = [:]
+
+    private init() {}
+
+    // MARK: - Connection
+
+    func connect(to serverURL: URL) {
+        manager = SocketManager(
+            socketURL: serverURL,
+            config: [.log(false), .compress, .reconnects(true), .reconnectWait(2)]
+        )
+        socket = manager?.defaultSocket
+
+        socket?.on(clientEvent: .connect) { [weak self] _, _ in
+            DispatchQueue.main.async { self?.isConnected = true }
+        }
+        socket?.on(clientEvent: .disconnect) { [weak self] _, _ in
+            DispatchQueue.main.async { self?.isConnected = false }
+        }
+
+        // Re-attach all registered handlers after reconnect
+        socket?.on(clientEvent: .reconnect) { [weak self] _, _ in
+            self?.reattachHandlers()
+        }
+
+        socket?.connect()
+    }
+
+    func disconnect() {
+        socket?.disconnect()
+    }
+
+    // MARK: - Emit
+
+    func emit(_ event: ClientEvent, payload: Encodable) {
+        guard let socket, let data = try? JSONEncoder().encode(payload),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+        socket.emit(event.rawValue, dict)
+    }
+
+    // MARK: - Listen
+
+    /// Register a typed handler for a server event. Replaces any previous handler for the same event.
+    func on<T: Decodable>(_ event: ServerEvent, handler: @escaping (T) -> Void) {
+        let key = event.rawValue
+        socket?.off(key)
+        socket?.on(key) { data, _ in
+            guard let raw = data.first,
+                  let jsonData = try? JSONSerialization.data(withJSONObject: raw),
+                  let decoded = try? JSONDecoder().decode(T.self, from: jsonData)
+            else { return }
+            DispatchQueue.main.async { handler(decoded) }
+        }
+        // Store a type-erased copy for reconnect
+        handlers[key] = { [weak self] _ in _ = self }
+    }
+
+    func off(_ event: ServerEvent) {
+        socket?.off(event.rawValue)
+        handlers.removeValue(forKey: event.rawValue)
+    }
+
+    // MARK: - Private
+
+    private func reattachHandlers() {
+        // Handlers are re-registered by the owning view models via on(_:handler:)
+        // after receiving the reconnect notification. Nothing extra needed here.
+    }
+}

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,11 @@
+# ── Appfile ───────────────────────────────────────────────────────────────────
+# Set APPLE_ID and TEAM_ID in GitHub secrets or .env.local (never commit them).
+
+apple_id(ENV["APPLE_ID"] || "your@email.com")          # ← your Apple ID
+team_id(ENV["TEAM_ID"] || "XXXXXXXXXX")                  # ← 10-char Team ID
+
+# App IDs — must match project.yml bundle identifiers
+app_identifier([
+  "com.gamelab.controller",   # ← iOS phone controller
+  "com.gamelab.tv",           # ← tvOS board app
+])

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,135 @@
+
+# frozen_string_literal: true
+
+# ── Fastfile ──────────────────────────────────────────────────────────────────
+# Lanes:
+#   fastlane deploy_ios      — build iOS controller app → TestFlight
+#   fastlane deploy_tvos     — build tvOS board app    → TestFlight
+#   fastlane deploy_all      — both in sequence
+#   fastlane build_ios       — build only (no upload), for PR checks
+#   fastlane build_tvos      — build only (no upload), for PR checks
+
+default_platform(:ios)
+
+# ── Shared App Store Connect API key setup ────────────────────────────────────
+def asc_api_key
+  app_store_connect_api_key(
+    key_id:        ENV.fetch("ASC_KEY_ID"),
+    issuer_id:     ENV.fetch("ASC_ISSUER_ID"),
+    key_content:   ENV.fetch("ASC_PRIVATE_KEY"),   # .p8 content, not path
+    in_house:      false,
+    is_key_content_base64: false
+  )
+end
+
+# ── iOS controller app ────────────────────────────────────────────────────────
+platform :ios do
+
+  desc "Build iOS controller app without uploading (PR check)"
+  lane :build_ios do
+    build_app(
+      workspace:          "GameLab.xcworkspace",
+      scheme:             "GameLabController",
+      configuration:      "Debug",
+      destination:        "generic/platform=iOS Simulator",
+      skip_codesigning:   true,
+      skip_archive:       true,
+      build_path:         "build/ios"
+    )
+  end
+
+  desc "Build + upload iOS controller app to TestFlight"
+  lane :deploy_ios do
+    api_key = asc_api_key
+
+    # Increment build number to match CI run number
+    increment_build_number(
+      xcodeproj:    "GameLab.xcodeproj",
+      build_number: ENV.fetch("GITHUB_RUN_NUMBER", "1")
+    )
+
+    build_app(
+      workspace:      "GameLab.xcworkspace",
+      scheme:         "GameLabController",
+      configuration:  "Release",
+      export_method:  "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "com.gamelab.controller" => ENV.fetch("IOS_PROVISION_PROFILE_NAME")
+        }
+      },
+      output_directory: "build/ios",
+      output_name:      "GameLabController.ipa"
+    )
+
+    upload_to_testflight(
+      api_key:            api_key,
+      ipa:                "build/ios/GameLabController.ipa",
+      app_identifier:     "com.gamelab.controller",
+      skip_waiting_for_build_processing: true,
+      changelog:          "Build #{ENV['GITHUB_RUN_NUMBER']} — #{ENV['GITHUB_SHA']&.slice(0, 7)}"
+    )
+  end
+
+end
+
+# ── tvOS board app ────────────────────────────────────────────────────────────
+platform :ios do   # Fastlane uses :ios platform for tvOS too
+
+  desc "Build tvOS board app without uploading (PR check)"
+  lane :build_tvos do
+    build_app(
+      workspace:        "GameLab.xcworkspace",
+      scheme:           "GameLabTV",
+      configuration:    "Debug",
+      destination:      "generic/platform=tvOS Simulator",
+      skip_codesigning: true,
+      skip_archive:     true,
+      build_path:       "build/tvos"
+    )
+  end
+
+  desc "Build + upload tvOS board app to TestFlight"
+  lane :deploy_tvos do
+    api_key = asc_api_key
+
+    increment_build_number(
+      xcodeproj:    "GameLab.xcodeproj",
+      build_number: ENV.fetch("GITHUB_RUN_NUMBER", "1")
+    )
+
+    build_app(
+      workspace:      "GameLab.xcworkspace",
+      scheme:         "GameLabTV",
+      configuration:  "Release",
+      export_method:  "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "com.gamelab.tv" => ENV.fetch("TVOS_PROVISION_PROFILE_NAME")
+        }
+      },
+      output_directory: "build/tvos",
+      output_name:      "GameLabTV.ipa"
+    )
+
+    upload_to_testflight(
+      api_key:            api_key,
+      ipa:                "build/tvos/GameLabTV.ipa",
+      app_identifier:     "com.gamelab.tv",
+      skip_waiting_for_build_processing: true,
+      changelog:          "Build #{ENV['GITHUB_RUN_NUMBER']} — #{ENV['GITHUB_SHA']&.slice(0, 7)}"
+    )
+  end
+
+  desc "Deploy both iOS and tvOS apps to TestFlight"
+  lane :deploy_all do
+    deploy_ios
+    deploy_tvos
+  end
+
+end
+
+# ── Error handler ─────────────────────────────────────────────────────────────
+error do |lane, exception|
+  UI.error "Lane #{lane} failed: #{exception.message}"
+end

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,105 @@
+# XcodeGen project spec — generates GameLab.xcodeproj on the fly.
+# Run: brew install xcodegen && xcodegen generate  (from ios/ directory)
+
+name: GameLab
+options:
+  bundleIdPrefix: com.gamelab           # ← CHANGE to your reverse-domain prefix
+  deploymentTarget:
+    iOS: "17.0"
+    tvOS: "17.0"
+  xcodeVersion: "15.4"
+  groupSortPosition: top
+  createIntermediateGroups: true
+  usesTabs: false
+  indentWidth: 4
+
+# Swift Package dependencies
+packages:
+  SocketIO:
+    url: https://github.com/socketio/socket.io-client-swift
+    from: "16.0.0"
+
+# ─── Targets ──────────────────────────────────────────────────────────────────
+
+targets:
+
+  # ── iPhone / iPad controller app ──────────────────────────────────────────
+  GameLabController:
+    type: application
+    platform: iOS
+    deploymentTarget: "17.0"
+
+    sources:
+      - path: GameLabController
+        excludes: ["*.plist"]
+      - path: Shared
+
+    dependencies:
+      - package: SocketIO
+        product: SocketIO
+
+    info:
+      path: GameLabController/Info.plist
+      properties:
+        CFBundleDisplayName: GameLab
+        CFBundleShortVersionString: "1.0"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        UILaunchScreen:
+          UIColorName: ""
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        NSMotionUsageDescription: "GameLab uses motion to let you tilt and shake your phone as a game controller."
+        NSLocalNetworkUsageDescription: "GameLab connects to the game server on your local network."
+
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.gamelab.controller   # ← CHANGE
+        SWIFT_VERSION: "5.9"
+        CURRENT_PROJECT_VERSION: 1
+        DEVELOPMENT_TEAM: ""        # ← set to your 10-char Team ID
+        CODE_SIGN_STYLE: Manual     # overridden to Automatic for local dev (see below)
+        CODE_SIGN_IDENTITY: "Apple Distribution"
+        PROVISIONING_PROFILE_SPECIFIER: "$(IOS_PROVISION_PROFILE_NAME)"
+      configs:
+        Debug:
+          CODE_SIGN_STYLE: Automatic
+          CODE_SIGN_IDENTITY: "Apple Development"
+          PROVISIONING_PROFILE_SPECIFIER: ""
+
+  # ── Apple TV board app ────────────────────────────────────────────────────
+  GameLabTV:
+    type: application
+    platform: tvOS
+    deploymentTarget: "17.0"
+
+    sources:
+      - path: GameLabTV
+        excludes: ["*.plist"]
+      - path: Shared
+
+    dependencies:
+      - package: SocketIO
+        product: SocketIO
+
+    info:
+      path: GameLabTV/Info.plist
+      properties:
+        CFBundleDisplayName: GameLab TV
+        CFBundleShortVersionString: "1.0"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSLocalNetworkUsageDescription: "GameLab TV connects to the game server on your local network."
+
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.gamelab.tv            # ← CHANGE
+        SWIFT_VERSION: "5.9"
+        CURRENT_PROJECT_VERSION: 1
+        DEVELOPMENT_TEAM: ""        # ← set to your 10-char Team ID
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_IDENTITY: "Apple Distribution"
+        PROVISIONING_PROFILE_SPECIFIER: "$(TVOS_PROVISION_PROFILE_NAME)"
+      configs:
+        Debug:
+          CODE_SIGN_STYLE: Automatic
+          CODE_SIGN_IDENTITY: "Apple Development"
+          PROVISIONING_PROFILE_SPECIFIER: ""


### PR DESCRIPTION
## Summary

- Adds a complete `ios/` directory with two Swift apps (tvOS board + iOS controller) sharing a common networking layer
- All 17 existing games + 5 invented games are modeled with full type metadata (player limits, categories, private-info flags, phone input styles)
- Phone shows private information (your poker hand, your heist role, your tambola ticket); TV shows the shared game board — same data, different views

## Architecture

```
iPhone/iPad app  ──── Socket.IO ────  Flask server  ──── Socket.IO ────  Apple TV app
  JoinRoomView                          (existing)                        GameSelectionView
  ControllerGameView   game_action ──>                <── game_state      TVGameBoardView
  (private screen)                   <── private_state                   (shared board)
```

TV generates a room code → phones enter it → everyone is in the same game.

## What's included (22 Swift files, 3 113 lines)

**Shared layer**
- `GameSocketManager` — singleton Socket.IO client with typed emit/on, auto-reconnect
- `GameMessage.swift` — all event enums + Codable payload structs + `AnyCodable`
- `Game.swift` — `GameID` enum for all 22 games with emoji, category, player range, input style
- `Room.swift` — `Room`, `Player`, `RoomState` models

**tvOS app**
- `TVGameSelectionView` — D-pad navigable grid with category filter sidebar, connection status
- `TVLobbyView` — animated room code display, live player list, start button
- `TVHeistBoardView` — full board: 7×7 grid, camera arc overlays, phase timer ring, player sidebar, winner banner
- `TVTriviaBoardView` — question display, animated A/B/C/D choice tiles, per-player score bar

**iOS controller app**
- `JoinRoomView` — large room-code entry with shake-to-clear, name field
- `WaitingView` — ready button, live player list
- `HeistControllerView` — **asymmetric**: Guard gets camera toggle grid (secret); Thief gets a D-pad (only sees their own position)
- `TriviaControllerView` — race-to-tap answer buttons that lock after submission
- `PokerControllerView` — private hand cards + bet slider + fold/check/bet
- `ShakeToRollControllerView` — CoreMotion shake → dice roll for Snake & Ladder
- `PongControllerView` — CoreMotion tilt → paddle position at 20 fps
- `MindMeldControllerView` — secret word input, submitted before reveal
- `HotGridControllerView` — blind 5×5 tile picker
- `StockPanicControllerView` — per-stock buy/sell buttons with private portfolio
- `SpeedSculptorControllerView` — finger drawing canvas with stroke capture + submit
- `TambolaControllerView` — tap-to-mark bingo ticket + "Claim Full House" button

## Invented games designed for this model

| Game | Why phone-as-controller is essential |
|---|---|
| **Heist** | Guard's cameras are secret; thieves see only their tile. TV shows the full vault. Pure asymmetric info — impossible without private screens. |
| **Stock Panic** | Portfolio is private. TV shows only the shared ticker + news. |
| **Mind Meld** | Everyone types in secret simultaneously. TV reveals all at once. |
| **Hot Grid** | Pick a tile blind on phone; TV reveals what's underneath. |
| **Speed Sculptor** | Phone is the drawing canvas. TV shows all drawings for voting. |

## Test plan

- [ ] Open `ios/` in Xcode, create tvOS + iOS targets, add shared files to both
- [ ] Add `socket.io-client-swift ≥ 16.0` via SPM in each target
- [ ] Set `AppConstants.serverURL` to your running Flask server
- [ ] Run tvOS app on Apple TV simulator → verify game selection grid appears
- [ ] Run iOS app on iPhone simulator → enter room code from TV → verify lobby
- [ ] Press "I'm Ready" on phone → verify player row updates on TV
- [ ] Start a Trivia game → verify question appears on TV, answer buttons on phone
- [ ] Start a Heist game → verify one player sees Guard view, others see Thief D-pad

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUjy3FyA1TSKMFbx6JpQTV)_